### PR TITLE
Repair `release-to-github` workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - v*
+  workflow_dispatch: # Use the GitHub CLI to trigger this workflow manually on any branch: `gh workflow run continuous-integration.yml --ref <branch-name>`.
 
 jobs:
   validate-code-quality:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Extract the version from the release branch name
         id: extract-version-from-release-branch-name
         run: |
-          echo "RELEASE_VERSION=${RELEASE_BRANCH_NAME#release/}" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=${RELEASE_BRANCH_NAME#release/}" >> $GITHUB_OUTPUT
         env:
           RELEASE_BRANCH_NAME: ${{ github.head_ref }}
       - name: Use Nimbus (Bot) in Git

--- a/.github/workflows/release-to-github.yml
+++ b/.github/workflows/release-to-github.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch: # Use the GitHub CLI to trigger this workflow manually on any release tag: `gh workflow run release-to-github.yml --ref <tag-name>`.
 
 jobs:
   release-to-github:
@@ -12,10 +13,12 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4 # https://github.com/actions/checkout
       - name: Extract the version from the release tag name
         id: extract-version-from-release-tag-name
         run: |
-          echo "RELEASE_VERSION=${RELEASE_TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "RELEASE_VERSION=${RELEASE_TAG_NAME#v}" >> $GITHUB_OUTPUT
         env:
           RELEASE_TAG_NAME: ${{ github.ref_name }}
       - name: Create a draft release in GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Generate build artifacts
         run: yarn run build
       - name: Prepare the release
-        run: yarn run release.prepare "$RELEASE_VERSION"
+        run: yarn run release.prepare $RELEASE_VERSION
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
       - name: Use Nimbus (Bot) in Git


### PR DESCRIPTION
The GitHub CLI requires the Git repository to be checked out.