### PR TITLE
Install Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["github>rainstormy/presets-renovate"],
+	"schedule": ["after 6pm and before 10pm every weekday"],
+	"timezone": "Europe/Copenhagen"
+}


### PR DESCRIPTION
Dependabot was originally enabled in commit 2f5a144 and temporarily disabled in commit 4c98878. This time, we'll use Renovate instead of Dependabot.