### PR TITLE
Downgrade Undici to 6.21.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,12 @@
 		"before 7am every weekday",
 		"every weekend"
 	],
-	"timezone": "Europe/Copenhagen"
+	"timezone": "Europe/Copenhagen",
+	"packageRules": [
+		{
+			"matchPackageNames": ["undici"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
+		}
+	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Downgrade [Undici](https://github.com/nodejs/undici) to 6.21.2 to preserve
+  compatibility with Node.js 20.
 
 ## [1.1.7] - 2025-03-30
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@actions/core": "1.11.1",
 		"@actions/github": "6.0.0",
 		"tslib": "2.8.1",
-		"undici": "7.6.0",
+		"undici": "6.21.2",
 		"zod": "3.24.2"
 	},
 	"// dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
       undici:
-        specifier: 7.6.0
-        version: 7.6.0
+        specifier: 6.21.2
+        version: 6.21.2
       zod:
         specifier: 3.24.2
         version: 3.24.2
@@ -912,9 +912,9 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  undici@7.6.0:
-    resolution: {integrity: sha512-gaFsbThjrDGvAaD670r81RZro/s6H2PVZF640Qn0p5kZK+/rim7/mmyfp2W7VB5vOMaFM8vuFBJUaMlaZTYHlA==}
-    engines: {node: '>=20.18.1'}
+  undici@6.21.2:
+    resolution: {integrity: sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==}
+    engines: {node: '>=18.17'}
 
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
@@ -1765,7 +1765,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@7.6.0: {}
+  undici@6.21.2: {}
 
   universal-user-agent@6.0.1: {}
 


### PR DESCRIPTION
```shell
pnpm add --save --save-exact undici@6.21.2
```

Undici 7 introduces a dependency on the `node:sqlite` module which is not available in Node.js 20.

```
node:internal/modules/esm/translators:391
    throw new ERR_UNKNOWN_BUILTIN_MODULE(url);
          ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
    at ModuleLoader.builtinStrategy (node:internal/modules/esm/translators:391:11)
    at #translate (node:internal/modules/esm/loader:431:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:478:27) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}

Node.js v20.19.0
```