### PR TITLE
Install Valibot

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
 		"@actions/github": "6.0.0",
 		"tslib": "2.8.1",
 		"undici": "6.21.2",
-		"zod": "3.24.4"
+		"valibot": "1.1.0"
 	},
 	"// dependencies": {
 		"@actions/core": "A runtime library for GitHub Actions that provides access to inputs such as the GitHub token.",
 		"@actions/github": "A runtime library for GitHub Actions that provides access to the GitHub REST API via Octokit.",
 		"tslib": "A runtime library that optimises TypeScript applications when the `importHelpers` option is enabled in `tsconfig.json`.",
 		"undici": "An HTTP client that implements the Fetch API on Node.js. It is a peer dependency of `@actions/core` and `@actions/github`.",
-		"zod": "Zod is a data validation library."
+		"valibot": "Valibot provides type-safe data validation."
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,9 @@ importers:
       undici:
         specifier: 6.21.2
         version: 6.21.2
-      zod:
-        specifier: 3.24.4
-        version: 3.24.4
+      valibot:
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.8.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -933,6 +933,14 @@ packages:
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@3.1.3:
     resolution: {integrity: sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1029,9 +1037,6 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
 snapshots:
 
@@ -1791,6 +1796,10 @@ snapshots:
 
   universal-user-agent@6.0.1: {}
 
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   vite-node@3.1.3(@types/node@20.17.32):
     dependencies:
       cac: 6.7.14
@@ -1888,5 +1897,3 @@ snapshots:
   wrappy@1.0.2: {}
 
   yallist@4.0.0: {}
-
-  zod@3.24.4: {}

--- a/src/github/InputParameters.ts
+++ b/src/github/InputParameters.ts
@@ -1,6 +1,5 @@
 import { parseConfiguration } from "+validator/Configuration"
 import core from "@actions/core"
-import type { ZodIssue } from "zod"
 
 export function configurationFromInputs(): ReturnType<
 	typeof parseConfiguration
@@ -51,9 +50,4 @@ export function configurationFromInputs(): ReturnType<
 			),
 		},
 	})
-}
-
-export function formatIssue(issue: ZodIssue): string {
-	const parameterName = issue.path.at(-1) ?? issue.path.join(".")
-	return `Input parameter '${parameterName}' ${issue.message}`
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import {
 	actionFailed,
 	actionSucceeded,
 } from "+github/ActionResult"
-import { configurationFromInputs, formatIssue } from "+github/InputParameters"
+import { configurationFromInputs } from "+github/InputParameters"
 import { getPullRequestFromApi } from "+github/PullRequest"
 import { instructiveReporter } from "+validator/Reporter"
 import { validatorFrom } from "+validator/Validator"
@@ -35,17 +35,14 @@ async function run(): Promise<ActionResult> {
 	const configuration = configurationFromInputs()
 
 	if (!configuration.success) {
-		const formattedErrors = configuration.error.issues.map((issue) =>
-			formatIssue(issue),
-		)
-
+		const formattedErrors = configuration.issues.map((issue) => issue.message)
 		return actionFailed(formattedErrors)
 	}
 
 	const pullRequest = await getPullRequestFromApi(pullRequestNumber)
 
-	const reporter = instructiveReporter(configuration.data)
-	const validate = validatorFrom(configuration.data)
+	const reporter = instructiveReporter(configuration.output)
+	const validate = validatorFrom(configuration.output)
 	const reportedErrors = validate(pullRequest.rawCommits, reporter)
 
 	return reportedErrors.length === 0

--- a/src/rules/AcknowledgedAuthorEmailAddresses/AcknowledgedAuthorEmailAddressesConfiguration.tests.ts
+++ b/src/rules/AcknowledgedAuthorEmailAddresses/AcknowledgedAuthorEmailAddressesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	acknowledgedAuthorEmailAddressesConfigurationSchema,
 } from "+rules/AcknowledgedAuthorEmailAddresses/AcknowledgedAuthorEmailAddressesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -31,11 +32,11 @@ describe.each`
 
 describe.each`
 	rawPatterns                                                                                                                                        | expectedErrorMessage
-	${""}                                                                                                                                              | ${"must specify at least one value"}
-	${"  "}                                                                                                                                            | ${"must specify at least one value"}
-	${"\\d+\\+.+@users\\.noreply\\.github\\.com \\d+\\+.+@users\\.noreply\\.github\\.com"}                                                             | ${"must not contain duplicates: \\\\d+\\\\+.+@users\\\\.noreply\\\\.github\\\\.com"}
-	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@alpha-company\\.com"}                                                 | ${"must not contain duplicates: .+@alpha-company\\\\.com"}
-	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@charlie-company\\.com .+@bravo-company\\.com .+@bravo-company\\.com"} | ${"must not contain duplicates: .+@bravo-company\\\\.com .+@charlie-company\\\\.com"}
+	${""}                                                                                                                                              | ${"Input parameter 'acknowledged-author-email-addresses--patterns' must specify at least one value"}
+	${"  "}                                                                                                                                            | ${"Input parameter 'acknowledged-author-email-addresses--patterns' must specify at least one value"}
+	${"\\d+\\+.+@users\\.noreply\\.github\\.com \\d+\\+.+@users\\.noreply\\.github\\.com"}                                                             | ${"Input parameter 'acknowledged-author-email-addresses--patterns' must not contain duplicates: \\d+\\+.+@users\\.noreply\\.github\\.com"}
+	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@alpha-company\\.com"}                                                 | ${"Input parameter 'acknowledged-author-email-addresses--patterns' must not contain duplicates: .+@alpha-company\\.com"}
+	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@charlie-company\\.com .+@bravo-company\\.com .+@bravo-company\\.com"} | ${"Input parameter 'acknowledged-author-email-addresses--patterns' must not contain duplicates: .+@bravo-company\\.com .+@charlie-company\\.com"}
 `(
 	"a list of patterns from an invalid string of $rawPatterns",
 	(testRow: {
@@ -49,19 +50,14 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ patterns: rawPatterns })).toThrow(
-				"acknowledged-author-email-addresses--patterns",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawAcknowledgedAuthorEmailAddressesConfiguration,
 ): AcknowledgedAuthorEmailAddressesConfiguration {
-	return acknowledgedAuthorEmailAddressesConfigurationSchema.parse(
+	return parse(
+		acknowledgedAuthorEmailAddressesConfigurationSchema,
 		rawConfiguration,
 	)
 }

--- a/src/rules/AcknowledgedAuthorEmailAddresses/AcknowledgedAuthorEmailAddressesConfiguration.ts
+++ b/src/rules/AcknowledgedAuthorEmailAddresses/AcknowledgedAuthorEmailAddressesConfiguration.ts
@@ -4,28 +4,38 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const acknowledgedAuthorEmailAddressesConfigurationSchema = z.object({
-	patterns: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["acknowledged-author-email-addresses--patterns"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				" ",
-			)}`,
-			path: ["acknowledged-author-email-addresses--patterns"],
-		})),
+export const acknowledgedAuthorEmailAddressesConfigurationSchema = object({
+	patterns: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'acknowledged-author-email-addresses--patterns' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'acknowledged-author-email-addresses--patterns' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawAcknowledgedAuthorEmailAddressesConfiguration = z.input<
+export type RawAcknowledgedAuthorEmailAddressesConfiguration = InferInput<
 	typeof acknowledgedAuthorEmailAddressesConfigurationSchema
 >
 
-export type AcknowledgedAuthorEmailAddressesConfiguration = z.output<
+export type AcknowledgedAuthorEmailAddressesConfiguration = InferOutput<
 	typeof acknowledgedAuthorEmailAddressesConfigurationSchema
 >

--- a/src/rules/AcknowledgedAuthorNames/AcknowledgedAuthorNamesConfiguration.tests.ts
+++ b/src/rules/AcknowledgedAuthorNames/AcknowledgedAuthorNamesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	acknowledgedAuthorNamesConfigurationSchema,
 } from "+rules/AcknowledgedAuthorNames/AcknowledgedAuthorNamesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -31,10 +32,10 @@ describe.each`
 
 describe.each`
 	rawPatterns                          | expectedErrorMessage
-	${""}                                | ${"must specify at least one value"}
-	${"  "}                              | ${"must specify at least one value"}
-	${".+ .+"}                           | ${"must not contain duplicates: .+"}
-	${"\\w+\\.\\w+ .+\\s.+ \\w+\\.\\w+"} | ${"must not contain duplicates: \\\\w+\\\\.\\\\w+"}
+	${""}                                | ${"Input parameter 'acknowledged-author-names--patterns' must specify at least one value"}
+	${"  "}                              | ${"Input parameter 'acknowledged-author-names--patterns' must specify at least one value"}
+	${".+ .+"}                           | ${"Input parameter 'acknowledged-author-names--patterns' must not contain duplicates: .+"}
+	${"\\w+\\.\\w+ .+\\s.+ \\w+\\.\\w+"} | ${"Input parameter 'acknowledged-author-names--patterns' must not contain duplicates: \\w+\\.\\w+"}
 `(
 	"a list of patterns from an invalid string of $rawPatterns",
 	(testRow: {
@@ -48,19 +49,13 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ patterns: rawPatterns })).toThrow(
-				"acknowledged-author-names--patterns",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawAcknowledgedAuthorNamesConfiguration,
 ): AcknowledgedAuthorNamesConfiguration {
-	return acknowledgedAuthorNamesConfigurationSchema.parse(rawConfiguration)
+	return parse(acknowledgedAuthorNamesConfigurationSchema, rawConfiguration)
 }
 
 function formatPatterns(patterns: ReadonlyArray<string>): string {

--- a/src/rules/AcknowledgedAuthorNames/AcknowledgedAuthorNamesConfiguration.ts
+++ b/src/rules/AcknowledgedAuthorNames/AcknowledgedAuthorNamesConfiguration.ts
@@ -4,28 +4,38 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const acknowledgedAuthorNamesConfigurationSchema = z.object({
-	patterns: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["acknowledged-author-names--patterns"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				" ",
-			)}`,
-			path: ["acknowledged-author-names--patterns"],
-		})),
+export const acknowledgedAuthorNamesConfigurationSchema = object({
+	patterns: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'acknowledged-author-names--patterns' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'acknowledged-author-names--patterns' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawAcknowledgedAuthorNamesConfiguration = z.input<
+export type RawAcknowledgedAuthorNamesConfiguration = InferInput<
 	typeof acknowledgedAuthorNamesConfigurationSchema
 >
 
-export type AcknowledgedAuthorNamesConfiguration = z.output<
+export type AcknowledgedAuthorNamesConfiguration = InferOutput<
 	typeof acknowledgedAuthorNamesConfigurationSchema
 >

--- a/src/rules/AcknowledgedCommitterEmailAddresses/AcknowledgedCommitterEmailAddressesConfiguration.tests.ts
+++ b/src/rules/AcknowledgedCommitterEmailAddresses/AcknowledgedCommitterEmailAddressesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	acknowledgedCommitterEmailAddressesConfigurationSchema,
 } from "+rules/AcknowledgedCommitterEmailAddresses/AcknowledgedCommitterEmailAddressesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -31,11 +32,11 @@ describe.each`
 
 describe.each`
 	rawPatterns                                                                                                                                        | expectedErrorMessage
-	${""}                                                                                                                                              | ${"must specify at least one value"}
-	${"  "}                                                                                                                                            | ${"must specify at least one value"}
-	${"\\d+\\+.+@users\\.noreply\\.github\\.com \\d+\\+.+@users\\.noreply\\.github\\.com"}                                                             | ${"must not contain duplicates: \\\\d+\\\\+.+@users\\\\.noreply\\\\.github\\\\.com"}
-	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@alpha-company\\.com"}                                                 | ${"must not contain duplicates: .+@alpha-company\\\\.com"}
-	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@charlie-company\\.com .+@bravo-company\\.com .+@bravo-company\\.com"} | ${"must not contain duplicates: .+@bravo-company\\\\.com .+@charlie-company\\\\.com"}
+	${""}                                                                                                                                              | ${"Input parameter 'acknowledged-committer-email-addresses--patterns' must specify at least one value"}
+	${"  "}                                                                                                                                            | ${"Input parameter 'acknowledged-committer-email-addresses--patterns' must specify at least one value"}
+	${"\\d+\\+.+@users\\.noreply\\.github\\.com \\d+\\+.+@users\\.noreply\\.github\\.com"}                                                             | ${"Input parameter 'acknowledged-committer-email-addresses--patterns' must not contain duplicates: \\d+\\+.+@users\\.noreply\\.github\\.com"}
+	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@alpha-company\\.com"}                                                 | ${"Input parameter 'acknowledged-committer-email-addresses--patterns' must not contain duplicates: .+@alpha-company\\.com"}
+	${".+@alpha-company\\.com .+@bravo-company\\.com .+@charlie-company\\.com .+@charlie-company\\.com .+@bravo-company\\.com .+@bravo-company\\.com"} | ${"Input parameter 'acknowledged-committer-email-addresses--patterns' must not contain duplicates: .+@bravo-company\\.com .+@charlie-company\\.com"}
 `(
 	"a list of patterns from an invalid string of $rawPatterns",
 	(testRow: {
@@ -49,19 +50,14 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ patterns: rawPatterns })).toThrow(
-				"acknowledged-committer-email-addresses--patterns",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawAcknowledgedCommitterEmailAddressesConfiguration,
 ): AcknowledgedCommitterEmailAddressesConfiguration {
-	return acknowledgedCommitterEmailAddressesConfigurationSchema.parse(
+	return parse(
+		acknowledgedCommitterEmailAddressesConfigurationSchema,
 		rawConfiguration,
 	)
 }

--- a/src/rules/AcknowledgedCommitterEmailAddresses/AcknowledgedCommitterEmailAddressesConfiguration.ts
+++ b/src/rules/AcknowledgedCommitterEmailAddresses/AcknowledgedCommitterEmailAddressesConfiguration.ts
@@ -4,28 +4,38 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const acknowledgedCommitterEmailAddressesConfigurationSchema = z.object({
-	patterns: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["acknowledged-committer-email-addresses--patterns"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				" ",
-			)}`,
-			path: ["acknowledged-committer-email-addresses--patterns"],
-		})),
+export const acknowledgedCommitterEmailAddressesConfigurationSchema = object({
+	patterns: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'acknowledged-committer-email-addresses--patterns' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'acknowledged-committer-email-addresses--patterns' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawAcknowledgedCommitterEmailAddressesConfiguration = z.input<
+export type RawAcknowledgedCommitterEmailAddressesConfiguration = InferInput<
 	typeof acknowledgedCommitterEmailAddressesConfigurationSchema
 >
 
-export type AcknowledgedCommitterEmailAddressesConfiguration = z.output<
+export type AcknowledgedCommitterEmailAddressesConfiguration = InferOutput<
 	typeof acknowledgedCommitterEmailAddressesConfigurationSchema
 >

--- a/src/rules/AcknowledgedCommitterNames/AcknowledgedCommitterNamesConfiguration.tests.ts
+++ b/src/rules/AcknowledgedCommitterNames/AcknowledgedCommitterNamesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	acknowledgedCommitterNamesConfigurationSchema,
 } from "+rules/AcknowledgedCommitterNames/AcknowledgedCommitterNamesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -31,10 +32,10 @@ describe.each`
 
 describe.each`
 	rawPatterns                          | expectedErrorMessage
-	${""}                                | ${"must specify at least one value"}
-	${"  "}                              | ${"must specify at least one value"}
-	${".+ .+"}                           | ${"must not contain duplicates: .+"}
-	${"\\w+\\.\\w+ .+\\s.+ \\w+\\.\\w+"} | ${"must not contain duplicates: \\\\w+\\\\.\\\\w+"}
+	${""}                                | ${"Input parameter 'acknowledged-committer-names--patterns' must specify at least one value"}
+	${"  "}                              | ${"Input parameter 'acknowledged-committer-names--patterns' must specify at least one value"}
+	${".+ .+"}                           | ${"Input parameter 'acknowledged-committer-names--patterns' must not contain duplicates: .+"}
+	${"\\w+\\.\\w+ .+\\s.+ \\w+\\.\\w+"} | ${"Input parameter 'acknowledged-committer-names--patterns' must not contain duplicates: \\w+\\.\\w+"}
 `(
 	"a list of patterns from an invalid string of $rawPatterns",
 	(testRow: {
@@ -48,19 +49,13 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ patterns: rawPatterns })).toThrow(
-				"acknowledged-committer-names--patterns",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawAcknowledgedCommitterNamesConfiguration,
 ): AcknowledgedCommitterNamesConfiguration {
-	return acknowledgedCommitterNamesConfigurationSchema.parse(rawConfiguration)
+	return parse(acknowledgedCommitterNamesConfigurationSchema, rawConfiguration)
 }
 
 function formatPatterns(patterns: ReadonlyArray<string>): string {

--- a/src/rules/AcknowledgedCommitterNames/AcknowledgedCommitterNamesConfiguration.ts
+++ b/src/rules/AcknowledgedCommitterNames/AcknowledgedCommitterNamesConfiguration.ts
@@ -4,28 +4,38 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const acknowledgedCommitterNamesConfigurationSchema = z.object({
-	patterns: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["acknowledged-committer-names--patterns"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				" ",
-			)}`,
-			path: ["acknowledged-committer-names--patterns"],
-		})),
+export const acknowledgedCommitterNamesConfigurationSchema = object({
+	patterns: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'acknowledged-committer-names--patterns' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'acknowledged-committer-names--patterns' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawAcknowledgedCommitterNamesConfiguration = z.input<
+export type RawAcknowledgedCommitterNamesConfiguration = InferInput<
 	typeof acknowledgedCommitterNamesConfigurationSchema
 >
 
-export type AcknowledgedCommitterNamesConfiguration = z.output<
+export type AcknowledgedCommitterNamesConfiguration = InferOutput<
 	typeof acknowledgedCommitterNamesConfigurationSchema
 >

--- a/src/rules/ImperativeSubjectLines/ImperativeSubjectLinesConfiguration.tests.ts
+++ b/src/rules/ImperativeSubjectLines/ImperativeSubjectLinesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	imperativeSubjectLinesConfigurationSchema,
 } from "+rules/ImperativeSubjectLines/ImperativeSubjectLinesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -32,9 +33,9 @@ describe.each`
 
 describe.each`
 	rawWords                                           | expectedErrorMessage
-	${"chatify,chatify"}                               | ${"must not contain duplicates: chatify"}
-	${"deckenise,deckenize,chatify,chatify,deckenize"} | ${"must not contain duplicates: deckenize, chatify"}
-	${"deckenize,deckenise,deckenise,deckenize"}       | ${"must not contain duplicates: deckenize, deckenise"}
+	${"chatify,chatify"}                               | ${"Input parameter 'imperative-subject-lines--whitelist' must not contain duplicates: chatify"}
+	${"deckenise,deckenize,chatify,chatify,deckenize"} | ${"Input parameter 'imperative-subject-lines--whitelist' must not contain duplicates: deckenize, chatify"}
+	${"deckenize,deckenise,deckenise,deckenize"}       | ${"Input parameter 'imperative-subject-lines--whitelist' must not contain duplicates: deckenize, deckenise"}
 `(
 	"a whitelist of words from an invalid string of $rawWords",
 	(testRow: {
@@ -48,19 +49,13 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ whitelist: rawWords })).toThrow(
-				"imperative-subject-lines--whitelist",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawImperativeSubjectLinesConfiguration,
 ): ImperativeSubjectLinesConfiguration {
-	return imperativeSubjectLinesConfigurationSchema.parse(rawConfiguration)
+	return parse(imperativeSubjectLinesConfigurationSchema, rawConfiguration)
 }
 
 function formatWords(words: ReadonlyArray<string>): string {

--- a/src/rules/ImperativeSubjectLines/ImperativeSubjectLinesConfiguration.ts
+++ b/src/rules/ImperativeSubjectLines/ImperativeSubjectLinesConfiguration.ts
@@ -3,24 +3,34 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitByComma } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const imperativeSubjectLinesConfigurationSchema = z.object({
-	whitelist: z
-		.string()
-		.transform(splitByComma)
-		.refine(requireNoDuplicateValues, (words) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(words).join(
-				", ",
-			)}`,
-			path: ["imperative-subject-lines--whitelist"],
-		})),
+export const imperativeSubjectLinesConfigurationSchema = object({
+	whitelist: pipe(
+		string(),
+		transform(splitByComma),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'imperative-subject-lines--whitelist' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(", ")}`,
+		),
+	),
 })
 
-export type RawImperativeSubjectLinesConfiguration = z.input<
+export type RawImperativeSubjectLinesConfiguration = InferInput<
 	typeof imperativeSubjectLinesConfigurationSchema
 >
 
-export type ImperativeSubjectLinesConfiguration = z.output<
+export type ImperativeSubjectLinesConfiguration = InferOutput<
 	typeof imperativeSubjectLinesConfigurationSchema
 >

--- a/src/rules/IssueReferencesInSubjectLines/IssueReferencesInSubjectLinesConfiguration.tests.ts
+++ b/src/rules/IssueReferencesInSubjectLines/IssueReferencesInSubjectLinesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	issueReferencesInSubjectLinesConfigurationSchema,
 } from "+rules/IssueReferencesInSubjectLines/IssueReferencesInSubjectLinesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -32,11 +33,11 @@ describe.each`
 
 describe.each`
 	rawPatterns                                                                                                          | expectedErrorMessage
-	${""}                                                                                                                | ${"must specify at least one value"}
-	${"  "}                                                                                                              | ${"must specify at least one value"}
-	${"#[1-9][0-9]* #[1-9][0-9]*"}                                                                                       | ${"must not contain duplicates: #[1-9][0-9]*"}
-	${"ALPHA-[1-9][0-9]* BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]* ALPHA-[1-9][0-9]*"}                                       | ${"must not contain duplicates: ALPHA-[1-9][0-9]*"}
-	${"ALPHA-[1-9][0-9]* BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]* CHARLIE-[1-9][0-9]* BRAVO-[1-9][0-9]* BRAVO-[1-9][0-9]*"} | ${"must not contain duplicates: BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]*"}
+	${""}                                                                                                                | ${"Input parameter 'issue-references-in-subject-lines--patterns' must specify at least one value"}
+	${"  "}                                                                                                              | ${"Input parameter 'issue-references-in-subject-lines--patterns' must specify at least one value"}
+	${"#[1-9][0-9]* #[1-9][0-9]*"}                                                                                       | ${"Input parameter 'issue-references-in-subject-lines--patterns' must not contain duplicates: #[1-9][0-9]*"}
+	${"ALPHA-[1-9][0-9]* BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]* ALPHA-[1-9][0-9]*"}                                       | ${"Input parameter 'issue-references-in-subject-lines--patterns' must not contain duplicates: ALPHA-[1-9][0-9]*"}
+	${"ALPHA-[1-9][0-9]* BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]* CHARLIE-[1-9][0-9]* BRAVO-[1-9][0-9]* BRAVO-[1-9][0-9]*"} | ${"Input parameter 'issue-references-in-subject-lines--patterns' must not contain duplicates: BRAVO-[1-9][0-9]* CHARLIE-[1-9][0-9]*"}
 `(
 	"a list of patterns from an invalid string of $rawPatterns",
 	(testRow: {
@@ -52,15 +53,6 @@ describe.each`
 					patterns: rawPatterns,
 				}),
 			).toThrow(expectedErrorMessage)
-		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() =>
-				parseConfiguration({
-					allowedPositions: "as-prefix,as-suffix",
-					patterns: rawPatterns,
-				}),
-			).toThrow("issue-references-in-subject-lines--patterns")
 		})
 	},
 )
@@ -92,13 +84,13 @@ describe.each`
 
 describe.each`
 	rawPositions                                           | expectedErrorMessage
-	${""}                                                  | ${"must specify at least one value"}
-	${"  "}                                                | ${"must specify at least one value"}
-	${" ,   ,, , ,,, "}                                    | ${"must specify at least one value"}
-	${"as-prefix, as-infix, as-postfix, as-suffix"}        | ${"must not contain unknown values: as-infix, as-postfix"}
-	${"as-prefix,as-prefix"}                               | ${"must not contain duplicates: as-prefix"}
-	${"as-prefix,as-suffix,as-suffix"}                     | ${"must not contain duplicates: as-suffix"}
-	${"as-suffix,as-prefix,as-prefix,as-prefix,as-suffix"} | ${"must not contain duplicates: as-suffix, as-prefix"}
+	${""}                                                  | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must specify at least one value"}
+	${"  "}                                                | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must specify at least one value"}
+	${" ,   ,, , ,,, "}                                    | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must specify at least one value"}
+	${"as-prefix, as-infix, as-postfix, as-suffix"}        | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain unknown values: as-infix, as-postfix"}
+	${"as-prefix,as-prefix"}                               | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain duplicates: as-prefix"}
+	${"as-prefix,as-suffix,as-suffix"}                     | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain duplicates: as-suffix"}
+	${"as-suffix,as-prefix,as-prefix,as-prefix,as-suffix"} | ${"Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain duplicates: as-suffix, as-prefix"}
 `(
 	"a list of allowed positions from an invalid string of $rawPositions",
 	(testRow: {
@@ -115,22 +107,14 @@ describe.each`
 				}),
 			).toThrow(expectedErrorMessage)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() =>
-				parseConfiguration({
-					allowedPositions: rawPositions,
-					patterns: "UNICORN-[1-9][0-9]*",
-				}),
-			).toThrow("issue-references-in-subject-lines--allowed-positions")
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawIssueReferencesInSubjectLinesConfiguration,
 ): IssueReferencesInSubjectLinesConfiguration {
-	return issueReferencesInSubjectLinesConfigurationSchema.parse(
+	return parse(
+		issueReferencesInSubjectLinesConfigurationSchema,
 		rawConfiguration,
 	)
 }

--- a/src/rules/IssueReferencesInSubjectLines/IssueReferencesInSubjectLinesConfiguration.ts
+++ b/src/rules/IssueReferencesInSubjectLines/IssueReferencesInSubjectLinesConfiguration.ts
@@ -6,52 +6,67 @@ import {
 	requireNoUnknownValues,
 } from "+utilities/IterableUtilities"
 import { splitByComma, splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
 const issueReferencePositions = ["as-prefix", "as-suffix"] as const
 
 export type IssueReferencePosition = (typeof issueReferencePositions)[number]
+export type IssueReferencePositions = Array<IssueReferencePosition>
 
-export const issueReferencesInSubjectLinesConfigurationSchema = z.object({
-	allowedPositions: z
-		.string()
-		.transform(splitByComma)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["issue-references-in-subject-lines--allowed-positions"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				", ",
-			)}`,
-			path: ["issue-references-in-subject-lines--allowed-positions"],
-		}))
-		.refine(requireNoUnknownValues(issueReferencePositions), (values) => ({
-			message: `must not contain unknown values: ${getUnknownValues(
-				issueReferencePositions,
-				values,
-			).join(", ")}`,
-			path: ["issue-references-in-subject-lines--allowed-positions"],
-		})),
-	patterns: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["issue-references-in-subject-lines--patterns"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				" ",
-			)}`,
-			path: ["issue-references-in-subject-lines--patterns"],
-		})),
+export const issueReferencesInSubjectLinesConfigurationSchema = object({
+	allowedPositions: pipe(
+		string(),
+		transform(splitByComma),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'issue-references-in-subject-lines--allowed-positions' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(", ")}`,
+		),
+		check(
+			requireNoUnknownValues(issueReferencePositions),
+			(issue) =>
+				`Input parameter 'issue-references-in-subject-lines--allowed-positions' must not contain unknown values: ${getUnknownValues(
+					issueReferencePositions,
+					issue.input,
+				).join(", ")}`,
+		),
+		transform((input) => input as IssueReferencePositions),
+	),
+	patterns: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'issue-references-in-subject-lines--patterns' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'issue-references-in-subject-lines--patterns' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawIssueReferencesInSubjectLinesConfiguration = z.input<
+export type RawIssueReferencesInSubjectLinesConfiguration = InferInput<
 	typeof issueReferencesInSubjectLinesConfigurationSchema
 >
 
-export type IssueReferencesInSubjectLinesConfiguration = z.output<
+export type IssueReferencesInSubjectLinesConfiguration = InferOutput<
 	typeof issueReferencesInSubjectLinesConfigurationSchema
 >

--- a/src/rules/LimitLengthOfBodyLines/LimitLengthOfBodyLinesConfiguration.tests.ts
+++ b/src/rules/LimitLengthOfBodyLines/LimitLengthOfBodyLinesConfiguration.tests.ts
@@ -3,6 +3,7 @@ import {
 	type RawLimitLengthOfBodyLinesConfiguration,
 	limitLengthOfBodyLinesConfigurationSchema,
 } from "+rules/LimitLengthOfBodyLines/LimitLengthOfBodyLinesConfiguration"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -32,15 +33,15 @@ describe.each`
 
 describe.each`
 	rawMaximumCharacters | expectedErrorMessage
-	${""}                | ${"must be a positive integer:"}
-	${" "}               | ${"must be a positive integer:"}
-	${"."}               | ${"must be a positive integer: ."}
-	${"q"}               | ${"must be a positive integer: q"}
-	${"-1"}              | ${"must be a positive integer: -1"}
-	${"0"}               | ${"must be a positive integer: 0"}
-	${"54.5"}            | ${"must be a positive integer: 54.5"}
-	${"7abc"}            | ${"must be a positive integer: 7abc"}
-	${"1e9"}             | ${"must be a positive integer: 1e9"}
+	${""}                | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer:"}
+	${" "}               | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer:"}
+	${"."}               | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: ."}
+	${"q"}               | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: q"}
+	${"-1"}              | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: -1"}
+	${"0"}               | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: 0"}
+	${"54.5"}            | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: 54.5"}
+	${"7abc"}            | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: 7abc"}
+	${"1e9"}             | ${"Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: 1e9"}
 `(
 	"a maximum number of characters from an invalid string of $rawMaximumCharacters",
 	(testRow: {
@@ -54,17 +55,11 @@ describe.each`
 				parseConfiguration({ maximumCharacters: rawMaximumCharacters }),
 			).toThrow(expectedErrorMessage)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() =>
-				parseConfiguration({ maximumCharacters: rawMaximumCharacters }),
-			).toThrow("limit-length-of-body-lines--max-characters")
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawLimitLengthOfBodyLinesConfiguration,
 ): LimitLengthOfBodyLinesConfiguration {
-	return limitLengthOfBodyLinesConfigurationSchema.parse(rawConfiguration)
+	return parse(limitLengthOfBodyLinesConfigurationSchema, rawConfiguration)
 }

--- a/src/rules/LimitLengthOfBodyLines/LimitLengthOfBodyLinesConfiguration.ts
+++ b/src/rules/LimitLengthOfBodyLines/LimitLengthOfBodyLinesConfiguration.ts
@@ -1,20 +1,30 @@
 import { requirePositiveInteger } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const limitLengthOfBodyLinesConfigurationSchema = z.object({
-	maximumCharacters: z
-		.string()
-		.refine(requirePositiveInteger, (value) => ({
-			message: `must be a positive integer: ${value}`,
-			path: ["limit-length-of-body-lines--max-characters"],
-		}))
-		.transform((value) => Number.parseInt(value)),
+export const limitLengthOfBodyLinesConfigurationSchema = object({
+	maximumCharacters: pipe(
+		string(),
+		check(
+			requirePositiveInteger,
+			(issue) =>
+				`Input parameter 'limit-length-of-body-lines--max-characters' must be a positive integer: ${issue.input}`,
+		),
+		transform(Number.parseInt),
+	),
 })
 
-export type RawLimitLengthOfBodyLinesConfiguration = z.input<
+export type RawLimitLengthOfBodyLinesConfiguration = InferInput<
 	typeof limitLengthOfBodyLinesConfigurationSchema
 >
 
-export type LimitLengthOfBodyLinesConfiguration = z.output<
+export type LimitLengthOfBodyLinesConfiguration = InferOutput<
 	typeof limitLengthOfBodyLinesConfigurationSchema
 >

--- a/src/rules/LimitLengthOfSubjectLines/LimitLengthOfSubjectLinesConfiguration.tests.ts
+++ b/src/rules/LimitLengthOfSubjectLines/LimitLengthOfSubjectLinesConfiguration.tests.ts
@@ -3,6 +3,7 @@ import {
 	type RawLimitLengthOfSubjectLinesConfiguration,
 	limitLengthOfSubjectLinesConfigurationSchema,
 } from "+rules/LimitLengthOfSubjectLines/LimitLengthOfSubjectLinesConfiguration"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -32,15 +33,15 @@ describe.each`
 
 describe.each`
 	rawMaximumCharacters | expectedErrorMessage
-	${""}                | ${"must be a positive integer:"}
-	${" "}               | ${"must be a positive integer:"}
-	${"."}               | ${"must be a positive integer: ."}
-	${"q"}               | ${"must be a positive integer: q"}
-	${"-1"}              | ${"must be a positive integer: -1"}
-	${"0"}               | ${"must be a positive integer: 0"}
-	${"54.5"}            | ${"must be a positive integer: 54.5"}
-	${"7abc"}            | ${"must be a positive integer: 7abc"}
-	${"1e9"}             | ${"must be a positive integer: 1e9"}
+	${""}                | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer:"}
+	${" "}               | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer:"}
+	${"."}               | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: ."}
+	${"q"}               | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: q"}
+	${"-1"}              | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: -1"}
+	${"0"}               | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: 0"}
+	${"54.5"}            | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: 54.5"}
+	${"7abc"}            | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: 7abc"}
+	${"1e9"}             | ${"Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: 1e9"}
 `(
 	"a maximum number of characters from an invalid string of $rawMaximumCharacters",
 	(testRow: {
@@ -54,17 +55,11 @@ describe.each`
 				parseConfiguration({ maximumCharacters: rawMaximumCharacters }),
 			).toThrow(expectedErrorMessage)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() =>
-				parseConfiguration({ maximumCharacters: rawMaximumCharacters }),
-			).toThrow("limit-length-of-subject-lines--max-characters")
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawLimitLengthOfSubjectLinesConfiguration,
 ): LimitLengthOfSubjectLinesConfiguration {
-	return limitLengthOfSubjectLinesConfigurationSchema.parse(rawConfiguration)
+	return parse(limitLengthOfSubjectLinesConfigurationSchema, rawConfiguration)
 }

--- a/src/rules/LimitLengthOfSubjectLines/LimitLengthOfSubjectLinesConfiguration.ts
+++ b/src/rules/LimitLengthOfSubjectLines/LimitLengthOfSubjectLinesConfiguration.ts
@@ -1,20 +1,30 @@
 import { requirePositiveInteger } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const limitLengthOfSubjectLinesConfigurationSchema = z.object({
-	maximumCharacters: z
-		.string()
-		.refine(requirePositiveInteger, (value) => ({
-			message: `must be a positive integer: ${value}`,
-			path: ["limit-length-of-subject-lines--max-characters"],
-		}))
-		.transform((value) => Number.parseInt(value)),
+export const limitLengthOfSubjectLinesConfigurationSchema = object({
+	maximumCharacters: pipe(
+		string(),
+		check(
+			requirePositiveInteger,
+			(issue) =>
+				`Input parameter 'limit-length-of-subject-lines--max-characters' must be a positive integer: ${issue.input}`,
+		),
+		transform(Number.parseInt),
+	),
 })
 
-export type RawLimitLengthOfSubjectLinesConfiguration = z.input<
+export type RawLimitLengthOfSubjectLinesConfiguration = InferInput<
 	typeof limitLengthOfSubjectLinesConfigurationSchema
 >
 
-export type LimitLengthOfSubjectLinesConfiguration = z.output<
+export type LimitLengthOfSubjectLinesConfiguration = InferOutput<
 	typeof limitLengthOfSubjectLinesConfigurationSchema
 >

--- a/src/rules/NoSquashCommits/NoSquashCommitsConfiguration.tests.ts
+++ b/src/rules/NoSquashCommits/NoSquashCommitsConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	noSquashCommitsConfigurationSchema,
 } from "+rules/NoSquashCommits/NoSquashCommitsConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -33,12 +34,12 @@ describe.each`
 
 describe.each`
 	rawPrefixes                                     | expectedErrorMessage
-	${""}                                           | ${"must specify at least one value"}
-	${"  "}                                         | ${"must specify at least one value"}
-	${" ,   ,, , ,,, "}                             | ${"must specify at least one value"}
-	${"fixup!, squash!, fixup!"}                    | ${"must not contain duplicates: fixup!"}
-	${"squash!, squash!, amend!, fixup!, amend!"}   | ${"must not contain duplicates: squash!, amend!"}
-	${"amend!,fixup!,amend!,squash!,amend!,fixup!"} | ${"must not contain duplicates: amend!, fixup!"}
+	${""}                                           | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must specify at least one value"}
+	${"  "}                                         | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must specify at least one value"}
+	${" ,   ,, , ,,, "}                             | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must specify at least one value"}
+	${"fixup!, squash!, fixup!"}                    | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must not contain duplicates: fixup!"}
+	${"squash!, squash!, amend!, fixup!, amend!"}   | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must not contain duplicates: squash!, amend!"}
+	${"amend!,fixup!,amend!,squash!,amend!,fixup!"} | ${"Input parameter 'no-squash-commits--disallowed-prefixes' must not contain duplicates: amend!, fixup!"}
 `(
 	"a list of disallowed prefixes from an invalid string of $rawPrefixes",
 	(testRow: {
@@ -52,19 +53,13 @@ describe.each`
 				parseConfiguration({ disallowedPrefixes: rawPrefixes }),
 			).toThrow(expectedErrorMessage)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() =>
-				parseConfiguration({ disallowedPrefixes: rawPrefixes }),
-			).toThrow("no-squash-commits--disallowed-prefixes")
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawNoSquashCommitsConfiguration,
 ): NoSquashCommitsConfiguration {
-	return noSquashCommitsConfigurationSchema.parse(rawConfiguration)
+	return parse(noSquashCommitsConfigurationSchema, rawConfiguration)
 }
 
 function formatPrefixes(prefixes: ReadonlyArray<string>): string {

--- a/src/rules/NoSquashCommits/NoSquashCommitsConfiguration.ts
+++ b/src/rules/NoSquashCommits/NoSquashCommitsConfiguration.ts
@@ -4,28 +4,38 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitByComma } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const noSquashCommitsConfigurationSchema = z.object({
-	disallowedPrefixes: z
-		.string()
-		.transform(splitByComma)
-		.refine(requireAtLeastOneValue, {
-			message: "must specify at least one value",
-			path: ["no-squash-commits--disallowed-prefixes"],
-		})
-		.refine(requireNoDuplicateValues, (values) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(values).join(
-				", ",
-			)}`,
-			path: ["no-squash-commits--disallowed-prefixes"],
-		})),
+export const noSquashCommitsConfigurationSchema = object({
+	disallowedPrefixes: pipe(
+		string(),
+		transform(splitByComma),
+		check(
+			requireAtLeastOneValue,
+			"Input parameter 'no-squash-commits--disallowed-prefixes' must specify at least one value",
+		),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'no-squash-commits--disallowed-prefixes' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(", ")}`,
+		),
+	),
 })
 
-export type RawNoSquashCommitsConfiguration = z.input<
+export type RawNoSquashCommitsConfiguration = InferInput<
 	typeof noSquashCommitsConfigurationSchema
 >
 
-export type NoSquashCommitsConfiguration = z.output<
+export type NoSquashCommitsConfiguration = InferOutput<
 	typeof noSquashCommitsConfigurationSchema
 >

--- a/src/rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration.tests.ts
+++ b/src/rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration.tests.ts
@@ -4,6 +4,7 @@ import {
 	noTrailingPunctuationInSubjectLinesConfigurationSchema,
 } from "+rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -35,9 +36,9 @@ describe.each`
 
 describe.each`
 	rawSuffixes                | expectedErrorMessage
-	${". . ,"}                 | ${"must not contain duplicates: ."}
-	${", . ! : . ,"}           | ${"must not contain duplicates: , ."}
-	${"- + ! ? : : + + . , !"} | ${"must not contain duplicates: + ! :"}
+	${". . ,"}                 | ${"Input parameter 'no-trailing-punctuation-in-subject-lines--whitelist' must not contain duplicates: ."}
+	${", . ! : . ,"}           | ${"Input parameter 'no-trailing-punctuation-in-subject-lines--whitelist' must not contain duplicates: , ."}
+	${"- + ! ? : : + + . , !"} | ${"Input parameter 'no-trailing-punctuation-in-subject-lines--whitelist' must not contain duplicates: + ! :"}
 `(
 	"a whitelist of suffixes from an invalid string of $rawSuffixes",
 	(testRow: {
@@ -51,19 +52,14 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration({ whitelist: rawSuffixes })).toThrow(
-				"no-trailing-punctuation-in-subject-lines--whitelist",
-			)
-		})
 	},
 )
 
 function parseConfiguration(
 	rawConfiguration: RawNoTrailingPunctuationInSubjectLinesConfiguration,
 ): NoTrailingPunctuationInSubjectLinesConfiguration {
-	return noTrailingPunctuationInSubjectLinesConfigurationSchema.parse(
+	return parse(
+		noTrailingPunctuationInSubjectLinesConfigurationSchema,
 		rawConfiguration,
 	)
 }

--- a/src/rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration.ts
+++ b/src/rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration.ts
@@ -3,24 +3,34 @@ import {
 	requireNoDuplicateValues,
 } from "+utilities/IterableUtilities"
 import { splitBySpace } from "+utilities/StringUtilities"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	check,
+	object,
+	pipe,
+	string,
+	transform,
+} from "valibot"
 
-export const noTrailingPunctuationInSubjectLinesConfigurationSchema = z.object({
-	whitelist: z
-		.string()
-		.transform(splitBySpace)
-		.refine(requireNoDuplicateValues, (suffixes) => ({
-			message: `must not contain duplicates: ${getDuplicateValues(
-				suffixes,
-			).join(" ")}`,
-			path: ["no-trailing-punctuation-in-subject-lines--whitelist"],
-		})),
+export const noTrailingPunctuationInSubjectLinesConfigurationSchema = object({
+	whitelist: pipe(
+		string(),
+		transform(splitBySpace),
+		check(
+			requireNoDuplicateValues,
+			(issue) =>
+				`Input parameter 'no-trailing-punctuation-in-subject-lines--whitelist' must not contain duplicates: ${getDuplicateValues(
+					issue.input,
+				).join(" ")}`,
+		),
+	),
 })
 
-export type RawNoTrailingPunctuationInSubjectLinesConfiguration = z.input<
+export type RawNoTrailingPunctuationInSubjectLinesConfiguration = InferInput<
 	typeof noTrailingPunctuationInSubjectLinesConfigurationSchema
 >
 
-export type NoTrailingPunctuationInSubjectLinesConfiguration = z.output<
+export type NoTrailingPunctuationInSubjectLinesConfiguration = InferOutput<
 	typeof noTrailingPunctuationInSubjectLinesConfigurationSchema
 >

--- a/src/rules/Rule.ts
+++ b/src/rules/Rule.ts
@@ -23,6 +23,7 @@ export const ruleKeys = [
 ] as const
 
 export type RuleKey = (typeof ruleKeys)[number]
+export type RuleKeys = ReadonlyArray<RuleKey>
 
 export type Rule = {
 	readonly key: RuleKey

--- a/src/rules/RulesConfiguration.tests.ts
+++ b/src/rules/RulesConfiguration.tests.ts
@@ -1,6 +1,7 @@
 import { type RuleKey, ruleKeys as allAvailableRuleKeys } from "+rules/Rule"
 import { ruleKeysConfigurationSchema } from "+rules/RulesConfiguration"
 import { count } from "+utilities/StringUtilities"
+import { parse } from "valibot"
 import { describe, expect, it } from "vitest"
 
 describe.each`
@@ -51,15 +52,14 @@ describe.each`
 
 describe.each`
 	rawRuleKeys                                                                                                                          | expectedErrorMessage
-	${""}                                                                                                                                | ${"must specify at least one value"}
-	${"  "}                                                                                                                              | ${"must specify at least one value"}
-	${" ,   ,, , ,,, "}                                                                                                                  | ${"must specify at least one value"}
-	${"capitalised-subject-lines, no-squash-commits, no-squash-commits"}                                                                 | ${"must not contain duplicates: no-squash-commits"}
-	${"capitalised-subject-lines, no-merge-commits, no-squash-commits, no-squash-commits, capitalised-subject-lines, no-squash-commits"} | ${"must not contain duplicates: capitalised-subject-lines, no-squash-commits"}
-	${"no-merge-commits, no-squash-commits, no-merge-commits, no-squash-commits"}                                                        | ${"must not contain duplicates: no-merge-commits, no-squash-commits"}
-	${"only-merge-commits, no-squash-commits, no-funny-commits, capitalised-subject-lines"}                                              | ${"must not contain unknown values: only-merge-commits, no-funny-commits"}
-	${"no-easter-eggs, no-squash-commits, no-easter-eggs, no-letters-in-subject-lines, no-squash-commits"}                               | ${"must not contain duplicates: no-easter-eggs, no-squash-commits"}
-	${"no-easter-eggs, no-squash-commits, no-easter-eggs, no-letters-in-subject-lines, no-squash-commits"}                               | ${"must not contain unknown values: no-easter-eggs, no-letters-in-subject-lines"}
+	${""}                                                                                                                                | ${"Input parameter 'rules' must specify at least one value"}
+	${"  "}                                                                                                                              | ${"Input parameter 'rules' must specify at least one value"}
+	${" ,   ,, , ,,, "}                                                                                                                  | ${"Input parameter 'rules' must specify at least one value"}
+	${"capitalised-subject-lines, no-squash-commits, no-squash-commits"}                                                                 | ${"Input parameter 'rules' must not contain duplicates: no-squash-commits"}
+	${"capitalised-subject-lines, no-merge-commits, no-squash-commits, no-squash-commits, capitalised-subject-lines, no-squash-commits"} | ${"Input parameter 'rules' must not contain duplicates: capitalised-subject-lines, no-squash-commits"}
+	${"no-merge-commits, no-squash-commits, no-merge-commits, no-squash-commits"}                                                        | ${"Input parameter 'rules' must not contain duplicates: no-merge-commits, no-squash-commits"}
+	${"only-merge-commits, no-squash-commits, no-funny-commits, capitalised-subject-lines"}                                              | ${"Input parameter 'rules' must not contain unknown values: only-merge-commits, no-funny-commits"}
+	${"no-easter-eggs, no-squash-commits, no-easter-eggs, no-letters-in-subject-lines, no-squash-commits"}                               | ${"Input parameter 'rules' must not contain unknown values: no-easter-eggs, no-letters-in-subject-lines"}
 `(
 	"a ruleset from an invalid string of $rawRuleKeys",
 	(testRow: {
@@ -73,15 +73,11 @@ describe.each`
 				expectedErrorMessage,
 			)
 		})
-
-		it("raises an error that points out the name of the incorrect parameter", () => {
-			expect(() => parseConfiguration(rawRuleKeys)).toThrow("rules")
-		})
 	},
 )
 
 function parseConfiguration(rawRuleKeys: string): ReadonlyArray<RuleKey> {
-	return ruleKeysConfigurationSchema.parse(rawRuleKeys)
+	return parse(ruleKeysConfigurationSchema, rawRuleKeys)
 }
 
 function formatRuleKeys(ruleKeys: ReadonlyArray<string>): string {

--- a/src/validator/Configuration.ts
+++ b/src/validator/Configuration.ts
@@ -9,9 +9,15 @@ import { limitLengthOfSubjectLinesConfigurationSchema } from "+rules/LimitLength
 import { noSquashCommitsConfigurationSchema } from "+rules/NoSquashCommits/NoSquashCommitsConfiguration"
 import { noTrailingPunctuationInSubjectLinesConfigurationSchema } from "+rules/NoTrailingPunctuationInSubjectLines/NoTrailingPunctuationInSubjectLinesConfiguration"
 import { ruleKeysConfigurationSchema } from "+rules/RulesConfiguration"
-import { z } from "zod"
+import {
+	type InferInput,
+	type InferOutput,
+	type SafeParseResult,
+	object,
+	safeParse,
+} from "valibot"
 
-const configurationSchema = z.object({
+const configurationSchema = object({
 	ruleKeys: ruleKeysConfigurationSchema,
 	acknowledgedAuthorEmailAddresses:
 		acknowledgedAuthorEmailAddressesConfigurationSchema,
@@ -29,11 +35,11 @@ const configurationSchema = z.object({
 		noTrailingPunctuationInSubjectLinesConfigurationSchema,
 })
 
-export type RawConfiguration = z.input<typeof configurationSchema>
-export type Configuration = z.output<typeof configurationSchema>
+export type RawConfiguration = InferInput<typeof configurationSchema>
+export type Configuration = InferOutput<typeof configurationSchema>
 
 export function parseConfiguration(
 	rawConfiguration: RawConfiguration,
-): ReturnType<typeof configurationSchema.safeParse> {
-	return configurationSchema.safeParse(rawConfiguration)
+): SafeParseResult<typeof configurationSchema> {
+	return safeParse(configurationSchema, rawConfiguration)
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(() => {
 			alias: tsconfigPathAliases(),
 		},
 		ssr: {
-			noExternal: ["@actions/core", "@actions/github", "undici", "zod"],
+			noExternal: ["@actions/core", "@actions/github", "undici", "valibot"],
 		},
 		test: {
 			coverage: {


### PR DESCRIPTION
It replaces Zod as the data validation library on configuration objects to simplify schemas while making them easier to customise and also to slightly reduce the overall bundle size.

```shell
pnpm add --save valibot
pnpm remove zod
```