### PR TITLE
Rename the project to Comet

### DIFF
--- a/.idea/runConfigurations/build_cli.xml
+++ b/.idea/runConfigurations/build_cli.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build_cli" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="mise run build_cli" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/build_gha.xml
+++ b/.idea/runConfigurations/build_gha.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build_gha" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="mise run build_gha" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/build_legacy_v1.xml
+++ b/.idea/runConfigurations/build_legacy_v1.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build_legacy_v1" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="mise run build_legacy_v1" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/bin/zsh" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="false" />
+    <option name="EXECUTE_SCRIPT_FILE" value="false" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,39 @@
 			"problemMatcher": []
 		},
 		{
+			"label": "build_cli",
+			"command": "mise run build_cli",
+			"type": "shell",
+			"presentation": {
+				"clear": true,
+				"panel": "shared",
+				"reveal": "always"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "build_gha",
+			"command": "mise run build_gha",
+			"type": "shell",
+			"presentation": {
+				"clear": true,
+				"panel": "shared",
+				"reveal": "always"
+			},
+			"problemMatcher": []
+		},
+		{
+			"label": "build_legacy_v1",
+			"command": "mise run build_legacy_v1",
+			"type": "shell",
+			"presentation": {
+				"clear": true,
+				"panel": "shared",
+				"reveal": "always"
+			},
+			"problemMatcher": []
+		},
+		{
 			"label": "check",
 			"command": "mise run check",
 			"type": "shell",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,18 @@
 - [Get started on 🟦 Windows](docs/quick-start/get-started-on-windows.md)
 
 ## Tasks
-| Name        | Description                                                                                                             |
-|-------------|-------------------------------------------------------------------------------------------------------------------------|
-| `build`     | Generates production-grade build artefacts with [Vite](https://vite.dev).                                               |
-| `check`     | Runs `check_fmt`, `check_gha`, and `check_ts`.                                                                          |
-| `check_fmt` | Verifies the code style of the source code with [Biome](https://biomejs.dev).                                           |
-| `check_gha` | Verifies the syntax of the GitHub Actions workflows with [actionlint](https://github.com/rhysd/actionlint).             |
-| `check_ts`  | Verifies the type safety of the source code with [TypeScript](https://www.typescriptlang.org).                          |
-| `fmt`       | Reformats the source code with [Biome](https://biomejs.dev).                                                            |
-| `init`      | Installs Node.js packages with [pnpm](https://pnpm.io) and enables the Git hooks with [Lefthook](https://lefthook.dev). |
-| `test`      | Runs the entire unit test suite once with [Vitest](https://vitest.dev).                                                 |
-| `vitest`    | Starts the [Vitest UI](https://vitest.dev/guide/ui.html#vitest-ui) test explorer for continuous unit testing.           |
-| `yolo`      | Disables the Git hooks with [Lefthook](https://lefthook.dev).                                                           |
+| Name              | Description                                                                                                             |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------|
+| `build`           | Runs `build_cli`, `build_gha`, and `build_legacy_v1`.                                                                   |
+| `build_cli`       | Generates production-grade build artefacts of the v2 command-line entrypoint with [Vite](https://vite.dev).             |
+| `build_gha`       | Generates production-grade build artefacts of the v2 GitHub Actions entrypoint with [Vite](https://vite.dev).           |
+| `build_legacy_v1` | Generates production-grade build artefacts of the legacy v1 GitHub Actions entrypoint with [Vite](https://vite.dev).    |
+| `check`           | Runs `check_fmt`, `check_gha`, and `check_ts`.                                                                          |
+| `check_fmt`       | Verifies the code style of the source code with [Biome](https://biomejs.dev).                                           |
+| `check_gha`       | Verifies the syntax of the GitHub Actions workflows with [actionlint](https://github.com/rhysd/actionlint).             |
+| `check_ts`        | Verifies the type safety of the source code with [TypeScript](https://www.typescriptlang.org).                          |
+| `fmt`             | Reformats the source code with [Biome](https://biomejs.dev).                                                            |
+| `init`            | Installs Node.js packages with [pnpm](https://pnpm.io) and enables the Git hooks with [Lefthook](https://lefthook.dev). |
+| `test`            | Runs the entire unit test suite once with [Vitest](https://vitest.dev).                                                 |
+| `vitest`          | Starts the [Vitest UI](https://vitest.dev/guide/ui.html#vitest-ui) test explorer for continuous unit testing.           |
+| `yolo`            | Disables the Git hooks with [Lefthook](https://lefthook.dev).                                                           |

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,7 @@
 	},
 	"overrides": [
 		{
-			"include": ["src/adapters/*.ts", "src/main.ts"],
+			"include": ["src/adapters/*.ts", "src/main.ts", "src/main-*.ts"],
 			"linter": {
 				"rules": {
 					"correctness": {
@@ -19,7 +19,7 @@
 			}
 		},
 		{
-			"include": ["src/main.ts"],
+			"include": ["src/main.ts", "src/main-*.ts"],
 			"linter": {
 				"rules": {
 					"style": {

--- a/mise.toml
+++ b/mise.toml
@@ -29,13 +29,13 @@ alias = ["cf"]
 # language=sh
 run = "actionlint"
 description = "Verifies the syntax of the GitHub Actions workflows with actionlint."
-alias = ["cg", "gha"]
+alias = ["cg"]
 
 [tasks.check_ts]
 # language=sh
 run = "tsc"
 description = "Verifies the type safety of the source code with TypeScript."
-alias = ["ct", "ts"]
+alias = ["ct"]
 
 [tasks.fmt]
 # language=sh

--- a/mise.toml
+++ b/mise.toml
@@ -9,10 +9,28 @@ node = "20.19.2"
 pnpm = "10.12.4"
 
 [tasks.build]
-# language=sh
-run = "vite build --ssr src/main.ts"
-description = "Generates production-grade build artefacts with Vite."
+depends = ["build_cli", "build_gha", "build_legacy_v1"]
+description = "Runs `build_cli`, `build_gha`, and `build_legacy_v1`."
 alias = ["b"]
+
+[tasks.build_cli]
+# language=sh
+run = "vite build --ssr src/main-cli.ts --outDir dist/cli/"
+env = { VITE_TARGET_PLATFORM = "cli" }
+description = "Generates production-grade build artefacts of the v2 command-line entrypoint with Vite."
+alias = ["bc"]
+
+[tasks.build_gha]
+# language=sh
+run = "vite build --ssr src/main-gha.ts --outDir dist/gha/"
+env = { VITE_TARGET_PLATFORM = "gha" }
+description = "Generates production-grade build artefacts of the v2 GitHub Actions entrypoint with Vite."
+alias = ["bg"]
+
+[tasks.build_legacy_v1]
+# language=sh
+run = "vite build --ssr src/main.ts --outDir dist/"
+description = "Generates production-grade build artefacts of the legacy v1 GitHub Actions entrypoint with Vite."
 
 [tasks.check]
 depends = ["check_fmt", "check_gha", "check_ts"]

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
 	"$schema": "https://json.schemastore.org/package.json",
-	"name": "@rainstormy/github-action-validate-commit-messages",
-	"version": "1.1.9",
+	"name": "@rainstormy/comet",
+	"version": "2.0.0-alpha.0",
 	"license": "MIT",
+	"author": "Steffen Diswal",
 	"private": true,
 	"type": "module",
 	"devDependencies": {

--- a/src/Vite.d.ts
+++ b/src/Vite.d.ts
@@ -1,0 +1,11 @@
+interface ViteTypeOptions {
+	strictImportMetaEnv: unknown
+}
+
+interface ImportMetaEnv {
+	VITE_TARGET_PLATFORM: "cli" | "gha"
+}
+
+interface ImportMeta {
+	env: ImportMetaEnv
+}

--- a/src/commits/Commit.ts
+++ b/src/commits/Commit.ts
@@ -1,0 +1,3 @@
+export type Commit = unknown
+
+export type Commits = Array<Commit>

--- a/src/commits/GetCommits.ts
+++ b/src/commits/GetCommits.ts
@@ -1,0 +1,12 @@
+import type { Commits } from "#commits/Commit"
+
+export async function getCommits(): Promise<Commits> {
+	switch (import.meta.env.VITE_TARGET_PLATFORM) {
+		case "cli": {
+			return ["cli"]
+		}
+		case "gha": {
+			return ["gha"]
+		}
+	}
+}

--- a/src/main-cli.ts
+++ b/src/main-cli.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import process, { argv } from "node:process"
+import { commandLineProgram } from "#programs/CommandLineProgram"
+
+const exitCode = await commandLineProgram(argv.slice(2))
+process.exit(exitCode)

--- a/src/main-gha.ts
+++ b/src/main-gha.ts
@@ -1,0 +1,5 @@
+import process from "node:process"
+import { githubActionsProgram } from "#programs/GithubActionsProgram"
+
+const exitCode = await githubActionsProgram()
+process.exit(exitCode)

--- a/src/programs/CommandLineProgram.tests.ts
+++ b/src/programs/CommandLineProgram.tests.ts
@@ -1,0 +1,83 @@
+import { injectLoggerMock } from "#utilities/logging/Logger.mocks"
+import { injectPackageJsonVersionMock } from "#utilities/packagejson/PackageJsonVersion.mocks"
+
+import { beforeEach, describe, expect, it } from "vitest"
+import { commandLineProgram } from "#programs/CommandLineProgram"
+import { getHelpText } from "#programs/CommandLineProgram"
+import { EXIT_CODE_SUCCESS, type ExitCode } from "#types/ExitCode"
+import type { SemanticVersionString } from "#types/SemanticVersionString"
+
+const { printMessage } = injectLoggerMock()
+const { getPackageJsonVersion } = injectPackageJsonVersionMock()
+
+describe.each`
+	args
+	${[]}
+	${["--help"]}
+	${["-h"]}
+	${["--config", "configs/comet.jsonc", "--help"]}
+	${["-h", "-v"]}
+`(
+	"when the args of $args contain the '--help'/'-h' flag",
+	(props: {
+		args: Array<string>
+	}) => {
+		let exitCode: ExitCode
+
+		beforeEach(async () => {
+			exitCode = await commandLineProgram(props.args)
+		})
+
+		it(`exits with ${EXIT_CODE_SUCCESS}`, () => {
+			expect(exitCode).toBe(EXIT_CODE_SUCCESS)
+		})
+
+		it("prints a help text with usage instructions", () => {
+			expect(printMessage).toHaveBeenCalledWith(getHelpText())
+			expect(printMessage).toHaveBeenCalledTimes(1)
+		})
+	},
+)
+
+describe("the help text", () => {
+	it("is a list of program arguments and options", () => {
+		expect(getHelpText()).toBe("Usage: comet [options]")
+	})
+
+	it("fits within 80 columns", () => {
+		const lines = getHelpText().split("\n")
+
+		for (const line of lines) {
+			expect(line.length).toBeLessThanOrEqual(80)
+		}
+	})
+})
+
+describe.each`
+	args                                                | version
+	${["--version"]}                                    | ${"1.0.0"}
+	${["-v"]}                                           | ${"2.0.8"}
+	${["--config", "configs/comet.jsonc", "--version"]} | ${"3.2.0-beta.1"}
+`(
+	"when the args of $args contain the '--version'/'-v' flag and the tool version in the 'package.json' file is $version",
+	(props: {
+		args: Array<string>
+		version: SemanticVersionString
+	}) => {
+		let exitCode: ExitCode
+
+		beforeEach(async () => {
+			getPackageJsonVersion.mockReturnValue(props.version)
+			exitCode = await commandLineProgram(props.args)
+		})
+
+		it(`exits with ${EXIT_CODE_SUCCESS}`, () => {
+			expect(exitCode).toBe(EXIT_CODE_SUCCESS)
+		})
+
+		it(`prints the tool version of '${props.version}'`, () => {
+			expect(printMessage).toHaveBeenCalledWith(props.version)
+			expect(printMessage).toHaveBeenCalledTimes(1)
+		})
+	},
+)

--- a/src/programs/CommandLineProgram.ts
+++ b/src/programs/CommandLineProgram.ts
@@ -1,0 +1,30 @@
+import { program } from "#programs/Program"
+import { EXIT_CODE_SUCCESS, type ExitCode } from "#types/ExitCode"
+import { printMessage } from "#utilities/logging/Logger"
+import { getPackageJsonVersion } from "#utilities/packagejson/PackageJsonVersion"
+
+export async function commandLineProgram(
+	args: Array<string>,
+): Promise<ExitCode> {
+	if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+		return helpProgram()
+	}
+	if (args.includes("--version") || args.includes("-v")) {
+		return versionProgram()
+	}
+	return program(args)
+}
+
+async function helpProgram(): Promise<ExitCode> {
+	printMessage(getHelpText())
+	return EXIT_CODE_SUCCESS
+}
+
+export function getHelpText(): string {
+	return "Usage: comet [options]"
+}
+
+async function versionProgram(): Promise<ExitCode> {
+	printMessage(getPackageJsonVersion())
+	return EXIT_CODE_SUCCESS
+}

--- a/src/programs/GithubActionsProgram.ts
+++ b/src/programs/GithubActionsProgram.ts
@@ -1,0 +1,6 @@
+import { program } from "#programs/Program"
+import type { ExitCode } from "#types/ExitCode"
+
+export async function githubActionsProgram(): Promise<ExitCode> {
+	return program([])
+}

--- a/src/programs/Program.ts
+++ b/src/programs/Program.ts
@@ -1,0 +1,10 @@
+import { getCommits } from "#commits/GetCommits"
+import { EXIT_CODE_GENERAL_ERROR, type ExitCode } from "#types/ExitCode"
+import { printMessage } from "#utilities/logging/Logger"
+
+export async function program(_args: Array<string>): Promise<ExitCode> {
+	const commits = await getCommits()
+	printMessage(commits.join(" "))
+	printMessage("Not implemented yet")
+	return EXIT_CODE_GENERAL_ERROR
+}

--- a/src/types/ExitCode.ts
+++ b/src/types/ExitCode.ts
@@ -1,0 +1,8 @@
+export const EXIT_CODE_SUCCESS = 0
+export const EXIT_CODE_GENERAL_ERROR = 1
+export const EXIT_CODE_INVALID_INPUT = 2
+
+export type ExitCode =
+	| typeof EXIT_CODE_SUCCESS
+	| typeof EXIT_CODE_GENERAL_ERROR
+	| typeof EXIT_CODE_INVALID_INPUT

--- a/src/types/ModuleMock.ts
+++ b/src/types/ModuleMock.ts
@@ -1,0 +1,7 @@
+import type { Mock } from "vitest"
+
+export type ModuleMock<
+	Module extends Record<string, (...params: never) => unknown>,
+> = {
+	[Name in keyof Module]: Mock<Module[Name]>
+}

--- a/src/types/SemanticVersionString.ts
+++ b/src/types/SemanticVersionString.ts
@@ -1,0 +1,5 @@
+export type SemanticVersionString =
+	| `${number}.${number}.${number}`
+	| `${number}.${number}.${number}+${string}`
+	| `${number}.${number}.${number}-${string}`
+	| `${number}.${number}.${number}-${string}+${string}`

--- a/src/utilities/logging/Logger.mocks.ts
+++ b/src/utilities/logging/Logger.mocks.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest"
+import type { ModuleMock } from "#types/ModuleMock"
+
+export type LoggerMock = ModuleMock<
+	typeof import("#utilities/logging/Logger") // CAUTION: `vi.mock()` below must always refer to the same path as here.
+>
+
+export function injectLoggerMock(): LoggerMock {
+	const mock = vi.hoisted<LoggerMock>(() => ({
+		printMessage: vi.fn(),
+	}))
+
+	vi.mock("#utilities/logging/Logger", () => mock)
+	return mock
+}

--- a/src/utilities/logging/Logger.ts
+++ b/src/utilities/logging/Logger.ts
@@ -1,0 +1,4 @@
+export function printMessage(message: string): void {
+	// biome-ignore lint/suspicious/noConsole: Using `console` is intentional in this case.
+	console.log(message)
+}

--- a/src/utilities/packagejson/PackageJsonVersion.mocks.ts
+++ b/src/utilities/packagejson/PackageJsonVersion.mocks.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest"
+import type { ModuleMock } from "#types/ModuleMock"
+
+export type PackageJsonVersionMock = ModuleMock<
+	typeof import("#utilities/packagejson/PackageJsonVersion") // CAUTION: `vi.mock()` below must always refer to the same path as here.
+>
+
+export function injectPackageJsonVersionMock(): PackageJsonVersionMock {
+	const mock = vi.hoisted<PackageJsonVersionMock>(() => ({
+		getPackageJsonVersion: vi.fn(),
+	}))
+
+	vi.mock("#utilities/packagejson/PackageJsonVersion", () => mock)
+	return mock
+}

--- a/src/utilities/packagejson/PackageJsonVersion.ts
+++ b/src/utilities/packagejson/PackageJsonVersion.ts
@@ -1,0 +1,9 @@
+import type { SemanticVersionString } from "#types/SemanticVersionString"
+import { version } from "#utilities/../../package.json" with { type: "json" }
+
+export type PackageJsonVersion = SemanticVersionString
+
+export function getPackageJsonVersion(): PackageJsonVersion {
+	// Vite inlines the `version` string imported from `package.json`.
+	return version as SemanticVersionString
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
 		"libReplacement": false,
 		"paths": {
 			"#adapters/*": ["src/adapters/*"],
+			"#commits/*": ["src/commits/*"],
+			"#programs/*": ["src/programs/*"],
 			"#rules/*": ["src/rules/*"],
+			"#types/*": ["src/types/*"],
 			"#utilities/*": ["src/utilities/*"],
 			"#validator/*": ["src/validator/*"]
 		},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,64 +1,38 @@
 import { join as joinPath, resolve as resolvePath } from "node:path"
+import { env } from "node:process"
 import { fileURLToPath } from "node:url"
-import { type ViteUserConfig as ViteConfig, defineConfig } from "vitest/config"
-import tsconfigJson from "./tsconfig.json" assert { type: "json" }
+import type { ViteUserConfig as ViteConfig } from "vitest/config"
 
-const projectDirectory = joinPath(fileURLToPath(import.meta.url), "..")
-
-export default defineConfig(() => {
-	const baseConfiguration: ViteConfig = {
-		build: {
-			emptyOutDir: true,
-			minify: "esbuild" as const,
-			reportCompressedSize: false,
-			rollupOptions: {
-				output: {
-					entryFileNames: "main.mjs",
-				},
+export default {
+	build: {
+		emptyOutDir: Boolean(env.VITE_TARGET_PLATFORM), // Prevent the `build_legacy_v1` task from deleting the `dist/cli` and `dist/gha` directories.
+		minify: "esbuild" as const,
+		reportCompressedSize: false,
+		rollupOptions: {
+			output: {
+				entryFileNames: env.VITE_TARGET_PLATFORM ? "index.js" : "main.mjs",
 			},
-			target: "es2022",
 		},
-		cacheDir: inProjectDirectory("node_modules/.cache/"),
-		plugins: [],
-		resolve: {
-			alias: tsconfigPathAliases(),
-		},
-		ssr: {
-			noExternal: ["valibot"],
-		},
-		test: {
-			include: ["src/**/*.tests.ts"],
-			mockReset: true,
-		},
-	}
+		target: "es2022",
+	},
+	cacheDir: path("node_modules/.cache/"),
+	plugins: [],
+	resolve: {
+		alias: [{ find: /^#(.+)/, replacement: path("src/$1") }],
+	},
+	ssr: {
+		noExternal: ["valibot"],
+	},
+	test: {
+		include: ["src/**/*.tests.ts"],
+		mockReset: true,
+	},
+} satisfies ViteConfig
 
-	return baseConfiguration
-})
-
-function tsconfigPathAliases(): Record<string, string> {
-	return Object.fromEntries(
-		Object.entries(tsconfigJson.compilerOptions.paths).map((entry) => {
-			assertSinglePath(entry)
-			const [alias, [path]] = entry
-			return [
-				alias.slice(0, -"/*".length),
-				inProjectDirectory(path.slice(0, -"/*".length)),
-			]
-		}),
-	)
-}
-
-function assertSinglePath(
-	entry: [alias: string, paths: Array<string>],
-): asserts entry is [alias: string, paths: [string]] {
-	const [alias, paths] = entry
-	if (paths.length !== 1) {
-		throw new Error(
-			`Path alias '${alias}' in 'tsconfig.json' must specify exactly one path, but has ${paths.length} paths`,
-		)
-	}
-}
-
-function inProjectDirectory(relativePath: string): string {
-	return resolvePath(projectDirectory, relativePath)
+/**
+ * Resolves a path relative to the project directory.
+ */
+function path(pathname: string): string {
+	const projectDirectory = joinPath(fileURLToPath(import.meta.url), "..")
+	return resolvePath(projectDirectory, pathname)
 }


### PR DESCRIPTION
In preparation for a new CLI entrypoint, the project needs a proper name
that you can type into the terminal. The GitHub repository retains the
current name `github-action-validate-commit-messages` for now to avoid
causing a breaking change in existing GitHub Actions workflows.