### PR TITLE
Prune the pnpm store in the workflow cache

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -48,6 +48,12 @@ runs:
       run: pnpm install --frozen-lockfile --ignore-scripts
       shell: bash
       #
+    - name: Prune the pnpm store before saving it to the workflow cache
+      if: success() && steps.skip-if-already-installed.outputs.installed != 'true'
+      # language=sh
+      run: pnpm store prune
+      shell: bash
+      #
     - name: Mark dependencies as installed on the current runner
       if: success() && steps.skip-if-already-installed.outputs.installed != 'true'
       # language=sh


### PR DESCRIPTION
We have observed that the workflow cache entries for pnpm keep growing in size in GitHub Actions.

`pnpm install` does not prune the store by itself. This commit makes the workflows prune the store explicitly.