### PR TITLE
Recognise concerns on revert and squash commits

### DIFF
--- a/src/domains/rules/NoRevertRevertCommits.tests.ts
+++ b/src/domains/rules/NoRevertRevertCommits.tests.ts
@@ -14,13 +14,15 @@ const enabled = ruleContext("noRevertRevertCommits")
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
 describe.each`
-	subjectLine                                                               | expectedRange
-	${'Revert "Revert "Fix the bug""'}                                        | ${[0, 16]}
-	${'Revert  "revert "Repair the soft ice machine""'}                       | ${[0, 17]}
-	${' revert " revert "Apply strawberry jam to make the code sweeter " " '} | ${[1, 18]}
-	${'  rEvErT "REVERT   "Refactor the authentication module""'}             | ${[2, 20]}
-	${'Revert "Revert "Revert "Fix the nasty bug"""'}                         | ${[0, 24]}
-	${' revert "revert  "revert "revert "Repair the soft ice machine """"'}   | ${[1, 34]}
+	subjectLine                                                                                   | expectedRange
+	${'Revert "Revert "Fix the bug""'}                                                            | ${[0, 16]}
+	${'Revert  "revert "Repair the soft ice machine""'}                                           | ${[0, 17]}
+	${' revert " revert "Apply strawberry jam to make the code sweeter " " '}                     | ${[1, 18]}
+	${'  rEvErT "REVERT   "Refactor the authentication module""'}                                 | ${[2, 20]}
+	${'Revert "Revert "Revert "Fix the nasty bug"""'}                                             | ${[0, 24]}
+	${' revert "revert  "revert "revert "Repair the soft ice machine """"'}                       | ${[1, 34]}
+	${'fixup! Revert "Revert "Add an amazing feature""'}                                          | ${[7, 23]}
+	${' squash!amend!  revert  "revert  "retrieve data from the exclusive third-party service""'} | ${[16, 34]}
 `(
 	"when the subject line of $subjectLine contains a revert marker with 2 or more 'revert' occurrences",
 	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
@@ -57,33 +59,6 @@ describe.each`
 	${'fixup! Revert "Add an amazing feature"'}
 `(
 	"when the subject line of $subjectLine contains a revert marker with 1 'revert' occurrence",
-	(props: { subjectLine: string }) => {
-		const commit = fakeCommit({ message: props.subjectLine })
-
-		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled.options)
-
-			it("does not raise any concerns", () => {
-				expect(actualConcerns).toEqual<Concerns>([])
-			})
-		})
-
-		describe("and the rule is disabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], null)
-
-			it("does not raise any concerns", () => {
-				expect(actualConcerns).toEqual<Concerns>([])
-			})
-		})
-	},
-)
-
-describe.each`
-	subjectLine
-	${'fixup! Revert "Revert "Add an amazing feature""'}
-	${' squash!amend!  revert  "revert  "retrieve data from the exclusive third-party service""'}
-`(
-	"when the subject line of $subjectLine contains a squash marker and a revert marker with 2 or more 'revert' occurrences",
 	(props: { subjectLine: string }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
@@ -166,6 +141,7 @@ describe("when verifying a set of multiple commits and some commits have revert 
 		it("raises concerns about the commits with double revert markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
 				subjectLineConcern(enabled, commits[0].sha, { range: [0, 16] }),
+				subjectLineConcern(enabled, commits[3].sha, { range: [8, 24] }),
 				subjectLineConcern(enabled, commits[5].sha, { range: [1, 17] }),
 				subjectLineConcern(enabled, commits[6].sha, { range: [0, 24] }),
 			])

--- a/src/domains/rules/NoRevertRevertCommits.ts
+++ b/src/domains/rules/NoRevertRevertCommits.ts
@@ -11,8 +11,6 @@ import { notNullish } from "#utilities/Arrays.ts"
  *
  * Cherry-picking the original commit provides more context, such as the original commit message and authorship.
  * This helps to preserve the traceability of the commit history.
- *
- * It ignores commits with squash markers.
  */
 export function noRevertRevertCommits(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
@@ -25,9 +23,6 @@ export function noRevertRevertCommits(commits: Commits, options: EmptyObject | n
 
 function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 	for (const token of commit.subjectLine) {
-		if (token.type === "squash-marker") {
-			return null
-		}
 		if (token.type === "revert-marker" && token.occurrences > 1) {
 			return subjectLineConcern(rule, commit.sha, {
 				range: trimmedTokenRange(token),

--- a/src/domains/rules/UseConciseSubjectLines.tests.ts
+++ b/src/domains/rules/UseConciseSubjectLines.tests.ts
@@ -126,6 +126,59 @@ describe.each`
 )
 
 describe.each`
+	subjectLine                                                                                 | expectedRange20 | expectedRange50
+	${"#510 Fixed a bug, but have probably introduced another one"}                             | ${[25, 58]}     | ${[55, 58]}
+	${"fixup! forgot to save my changes before entering the merge chaos"}                       | ${[27, 64]}     | ${[57, 64]}
+	${'Revert "retrieve data from the exclusive third-party service"'}                          | ${[28, 60]}     | ${[58, 60]}
+	${"fixup! GH-291 Resolve memory issues to make the code work better than it did last year"} | ${[34, 86]}     | ${[64, 86]}
+`(
+	"when the subject line of $subjectLine contains ignorable tokens and still exceeds 50 characters, but not 72 characters",
+	(props: {
+		subjectLine: string
+		expectedRange20: CharacterRange
+		expectedRange50: CharacterRange
+	}) => {
+		const commit = fakeCommit({ message: props.subjectLine })
+
+		describe("and the rule is enabled with a maximum length of 20 characters", () => {
+			const actualConcerns = useConciseSubjectLines([commit], enabled20.options)
+
+			it("raises a concern about the characters that exceed the limit", () => {
+				expect(actualConcerns).toEqual<Concerns>([
+					subjectLineConcern(enabled20, commit.sha, { range: props.expectedRange20 }),
+				])
+			})
+		})
+
+		describe("and the rule is enabled with a maximum length of 50 characters", () => {
+			const actualConcerns = useConciseSubjectLines([commit], enabled50.options)
+
+			it("raises a concern about the characters that exceed the limit", () => {
+				expect(actualConcerns).toEqual<Concerns>([
+					subjectLineConcern(enabled50, commit.sha, { range: props.expectedRange50 }),
+				])
+			})
+		})
+
+		describe("and the rule is enabled with a maximum length of 72 characters", () => {
+			const actualConcerns = useConciseSubjectLines([commit], enabled72.options)
+
+			it("does not raise any concerns", () => {
+				expect(actualConcerns).toEqual<Concerns>([])
+			})
+		})
+
+		describe("and the rule is disabled", () => {
+			const actualConcerns = useConciseSubjectLines([commit], null)
+
+			it("does not raise any concerns", () => {
+				expect(actualConcerns).toEqual<Concerns>([])
+			})
+		})
+	},
+)
+
+describe.each`
 	subjectLine                                                              | expectedRange20
 	${"Make the user interface less chaotic (GH-11) (GL-17)"}                | ${[20, 36]}
 	${"<#71238> free up unclaimed disk space"}                               | ${[29, 37]}
@@ -137,8 +190,10 @@ describe.each`
 	${"(GH-72): fix security vulnerability in `BridgeService`"}              | ${[29, 39]}
 	${"Make a smile to the `camera` again"}                                  | ${[28, 34]}
 	${"revisit the glorious `MaxDPS` algorithm"}                             | ${[20, 39]}
+	${'Revert "Revert "Revert "Fix the nasty bug from yesterday"""'}         | ${[44, 56]}
+	${"Squash! Make the program act like a clown"}                           | ${[28, 41]}
 `(
-	"when the subject line of $subjectLine contains tokens to be disregarded and still exceeds 20 characters, but not 50 characters",
+	"when the subject line of $subjectLine contains ignorable tokens and still exceeds 20 characters, but not 50 characters",
 	(props: { subjectLine: string; expectedRange20: CharacterRange }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
@@ -167,43 +222,6 @@ describe.each`
 				expect(actualConcerns).toEqual<Concerns>([])
 			})
 		})
-
-		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
-
-			it("does not raise any concerns", () => {
-				expect(actualConcerns).toEqual<Concerns>([])
-			})
-		})
-	},
-)
-
-describe.each`
-	subjectLine
-	${'Revert "retrieve data from the exclusive third-party service"'}
-	${'Revert "Revert "Revert "Fix the nasty bug from yesterday"""'}
-	${"fixup! Resolve memory issues to make the code work better than it did last year"}
-	${"Squash! Make the program act like a clown"}
-`(
-	"when the subject line of $subjectLine makes the commit disregardable",
-	(props: { subjectLine: string }) => {
-		const commit = fakeCommit({ message: props.subjectLine })
-
-		describe.each`
-			options
-			${enabled20.options}
-			${enabled50.options}
-			${enabled72.options}
-		`(
-			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(context: RuleContext<"useConciseSubjectLines">) => {
-				const actualConcerns = useConciseSubjectLines([commit], context.options)
-
-				it("does not raise any concerns", () => {
-					expect(actualConcerns).toEqual<Concerns>([])
-				})
-			},
-		)
 
 		describe("and the rule is disabled", () => {
 			const actualConcerns = useConciseSubjectLines([commit], null)
@@ -327,6 +345,7 @@ describe("when verifying a set of multiple commits and some commits have long su
 				subjectLineConcern(enabled20, commits[5].sha, { range: [25, 33] }),
 				subjectLineConcern(enabled20, commits[7].sha, { range: [20, 75] }),
 				subjectLineConcern(enabled20, commits[8].sha, { range: [20, 28] }),
+				subjectLineConcern(enabled20, commits[9].sha, { range: [27, 35] }),
 				subjectLineConcern(enabled20, commits[10].sha, { range: [89, 99] }),
 				subjectLineConcern(enabled20, commits[11].sha, { range: [20, 76] }),
 			])

--- a/src/domains/rules/UseConciseSubjectLines.ts
+++ b/src/domains/rules/UseConciseSubjectLines.ts
@@ -9,8 +9,8 @@ import { notNullish } from "#utilities/Arrays.ts"
  *
  * Keeping the subject line short helps to preserve the readability of the commit history in various Git clients.
  *
- * It ignores merge commits and commits with dependency versions, revert markers, or squash markers.
- * Issue links and inline code phrases do not count towards the limit.
+ * It ignores merge commits and commits with dependency versions.
+ * Issue links, inline code phrases, revert markers, and squash markers do not count towards the limit.
  */
 export function useConciseSubjectLines(
 	commits: Commits,
@@ -36,11 +36,7 @@ function verifyCommit(commit: Commit, rule: RuleContext<"useConciseSubjectLines"
 	let overflowEndIndex = 0
 
 	for (const token of commit.subjectLine) {
-		if (
-			token.type === "dependency-version" ||
-			token.type === "revert-marker" ||
-			token.type === "squash-marker"
-		) {
+		if (token.type === "dependency-version") {
 			return null
 		}
 		if (token.type === "text") {


### PR DESCRIPTION
Until now, `noRevertRevertCommits` and `useConciseSubjectLines` would disregard commits with revert markers or squash markers. Unfortunately, this could leave them undetected once the ancestor commit had been reworded to satisfy the rules.