### PR TITLE
Restore ignore-behaviour on revert markers

### DIFF
--- a/src/domains/rules/NoBlankSubjectLines.tests.ts
+++ b/src/domains/rules/NoBlankSubjectLines.tests.ts
@@ -61,14 +61,14 @@ describe.each`
 	${'amend! Revert " "'}                       | ${[15, 16]}
 	${'squash!fixup! revert " revert " GH-67 "'} | ${[37, 38]}
 `(
-	"when the subject line of $subjectLine starts with ignorable tokens and is blank otherwise",
+	"when the subject line of $subjectLine starts with insignificant tokens and is blank otherwise",
 	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
 			const actualConcerns = noBlankSubjectLines([commit], enabled.options)
 
-			it("raises a concern about the first character after the ignorable tokens", () => {
+			it("raises a concern about the first character after the insignificant tokens", () => {
 				expect(actualConcerns).toEqual<Concerns>([
 					subjectLineConcern(enabled, commit.sha, {
 						range: props.expectedRange,

--- a/src/domains/rules/NoBlankSubjectLines.ts
+++ b/src/domains/rules/NoBlankSubjectLines.ts
@@ -24,7 +24,7 @@ export function noBlankSubjectLines(commits: Commits, options: EmptyObject | nul
 }
 
 function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
-	let lastIgnorableToken: Token | null = null
+	let lastInsignificantToken: Token | null = null
 
 	for (const token of commit.subjectLine) {
 		if (
@@ -39,13 +39,13 @@ function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 			(token.type === "revert-marker" && token.occurrences > 0) ||
 			token.type === "squash-marker"
 		) {
-			lastIgnorableToken = token
+			lastInsignificantToken = token
 		}
 	}
 
 	const firstBlankIndex =
-		lastIgnorableToken !== null
-			? lastIgnorableToken.range[0] + lastIgnorableToken.value.trimEnd().length
+		lastInsignificantToken !== null
+			? lastInsignificantToken.range[0] + lastInsignificantToken.value.trimEnd().length
 			: 0
 
 	return subjectLineConcern(rule, commit.sha, {

--- a/src/domains/rules/NoSingleWordSubjectLines.tests.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.tests.ts
@@ -14,63 +14,33 @@ const enabled = ruleContext("noSingleWordSubjectLines")
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
 describe.each`
-	subjectLine           | expectedRange
-	${"-"}                | ${[0, 1]}
-	${".."}               | ${[0, 2]}
-	${"WIP"}              | ${[0, 3]}
-	${"wip!"}             | ${[0, 4]}
-	${"init"}             | ${[0, 4]}
-	${"test"}             | ${[0, 4]}
-	${"bugfix "}          | ${[0, 6]}
-	${"Unsubscribe"}      | ${[0, 11]}
-	${"#flabbergastered"} | ${[0, 16]}
-	${"HOTFIX"}           | ${[0, 6]}
-	${" Refactor"}        | ${[1, 9]}
-	${"  oops "}          | ${[2, 6]}
-	${"strategy-pattern"} | ${[0, 16]}
-	${"`Bingo`"}          | ${[0, 7]}
-	${"`EternalWealth`"}  | ${[0, 15]}
+	subjectLine                         | expectedRange
+	${"-"}                              | ${[0, 1]}
+	${".."}                             | ${[0, 2]}
+	${"WIP"}                            | ${[0, 3]}
+	${"wip!"}                           | ${[0, 4]}
+	${"init"}                           | ${[0, 4]}
+	${"test"}                           | ${[0, 4]}
+	${"bugfix "}                        | ${[0, 6]}
+	${"Unsubscribe"}                    | ${[0, 11]}
+	${"#flabbergastered"}               | ${[0, 16]}
+	${"HOTFIX"}                         | ${[0, 6]}
+	${" Refactor"}                      | ${[1, 9]}
+	${"  oops "}                        | ${[2, 6]}
+	${"strategy-pattern"}               | ${[0, 16]}
+	${"`Bingo`"}                        | ${[0, 7]}
+	${"`EternalWealth`"}                | ${[0, 15]}
+	${"Revert"}                         | ${[0, 6]}
+	${"#1 fix"}                         | ${[3, 6]}
+	${"(GH-31)   test"}                 | ${[10, 14]}
+	${"GL-7 `Unscheduled-Maintenance`"} | ${[5, 30]}
+	${"#2 #3 (GL-1) init"}              | ${[13, 17]}
+	${"fixup! WIP"}                     | ${[7, 10]}
+	${"squash!  bad"}                   | ${[9, 12]}
+	${"  amend!Hotfix"}                 | ${[8, 14]}
+	${"fixup! fixup! Restored"}         | ${[14, 22]}
 `(
-	"when the subject line of $subjectLine contains exactly one word",
-	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
-		const commit = fakeCommit({ message: props.subjectLine })
-
-		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
-
-			it("raises a concern about the single word", () => {
-				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
-				])
-			})
-		})
-
-		describe("and the rule is disabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], null)
-
-			it("does not raise any concerns", () => {
-				expect(actualConcerns).toEqual<Concerns>([])
-			})
-		})
-	},
-)
-
-describe.each`
-	subjectLine                                         | expectedRange
-	${"#1 fix"}                                         | ${[3, 6]}
-	${"(GH-31)   test"}                                 | ${[10, 14]}
-	${"GL-7 `Unscheduled-Maintenance`"}                 | ${[5, 30]}
-	${"#2 #3 (GL-1) init"}                              | ${[13, 17]}
-	${"fixup! WIP"}                                     | ${[7, 10]}
-	${"squash!  bad"}                                   | ${[9, 12]}
-	${"  amend!Hotfix"}                                 | ${[8, 14]}
-	${'Revert "dadada"'}                                | ${[8, 14]}
-	${'Revert "Revert "release""'}                      | ${[16, 23]}
-	${"fixup! fixup! Restored"}                         | ${[14, 22]}
-	${'amend! Revert " redacted"'}                      | ${[16, 24]}
-	${'squash!fixup! revert " revert " GH-67 cleanup"'} | ${[38, 45]}
-`(
-	"when the subject line of $subjectLine starts with ignorable tokens and has exactly one word otherwise",
+	"when the subject line of $subjectLine contains exactly one significant word",
 	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
@@ -99,38 +69,44 @@ describe.each`
 	${""}
 	${" "}
 	${"\t\t"}
-`("when the subject line of $subjectLine is blank", (props: { subjectLine: string }) => {
-	const commit = fakeCommit({ message: props.subjectLine })
-
-	describe("and the rule is enabled", () => {
-		const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
-
-		it("does not raise any concerns", () => {
-			expect(actualConcerns).toEqual<Concerns>([])
-		})
-	})
-
-	describe("and the rule is disabled", () => {
-		const actualConcerns = noSingleWordSubjectLines([commit], null)
-
-		it("does not raise any concerns", () => {
-			expect(actualConcerns).toEqual<Concerns>([])
-		})
-	})
-})
-
-describe.each`
-	subjectLine
 	${"#1"}
 	${"(GH-31)   "}
 	${"#2 #3 (GL-1) "}
 	${"  amend!"}
 	${"fixup! fixup! "}
-	${'Revert ""'}
-	${'squash!fixup! revert " revert " GH-67 "'}
 `(
-	"when the subject line of $subjectLine only contains ignorable tokens",
-	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
+	"when the subject line of $subjectLine is blank or contains only insignificant tokens",
+	(props: { subjectLine: string }) => {
+		const commit = fakeCommit({ message: props.subjectLine })
+
+		describe("and the rule is enabled", () => {
+			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
+
+			it("does not raise any concerns", () => {
+				expect(actualConcerns).toEqual<Concerns>([])
+			})
+		})
+
+		describe("and the rule is disabled", () => {
+			const actualConcerns = noSingleWordSubjectLines([commit], null)
+
+			it("does not raise any concerns", () => {
+				expect(actualConcerns).toEqual<Concerns>([])
+			})
+		})
+	},
+)
+
+describe.each`
+	subjectLine
+	${'revert ""'}
+	${'Revert "dadada"'}
+	${'Revert "Revert "release""'}
+	${'amend! Revert " redacted"'}
+	${'squash!fixup! revert " revert " GH-67 cleanup"'}
+`(
+	"when the subject line of $subjectLine contains a revert marker",
+	(props: { subjectLine: string }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {

--- a/src/domains/rules/NoSingleWordSubjectLines.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.ts
@@ -12,7 +12,8 @@ import { notEmptyString, notNullish } from "#utilities/Arrays.ts"
  * Providing more context in the commit message (such as a thorough description) helps to preserve
  * the traceability of the commit history.
  *
- * Leading issue links, revert markers, and squash markers do not count as words.
+ * It ignores commits with revert markers.
+ * Leading issue links and squash markers do not count as words.
  */
 export function noSingleWordSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
@@ -28,7 +29,7 @@ function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 	let firstWordToken: Token | null = null
 
 	for (const token of commit.subjectLine) {
-		if (words > 1 || (token.type === "issue-link" && words > 0)) {
+		if (words > 1 || (token.type === "issue-link" && words > 0) || token.type === "revert-marker") {
 			return null
 		}
 		if (

--- a/src/domains/rules/NoUnexpectedPunctuation.ts
+++ b/src/domains/rules/NoUnexpectedPunctuation.ts
@@ -4,6 +4,9 @@ import { type RuleContext, ruleContext } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
+/**
+ * It ignores revert commits.
+ */
 export function noUnexpectedPunctuation(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
 		return []

--- a/src/domains/rules/NoUnexpectedWhitespace.ts
+++ b/src/domains/rules/NoUnexpectedWhitespace.ts
@@ -4,6 +4,9 @@ import { type RuleContext, ruleContext } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
+/**
+ * It ignores revert commits.
+ */
 export function noUnexpectedWhitespace(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
 		return []

--- a/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
@@ -14,21 +14,23 @@ const enabled = ruleContext("useCapitalisedSubjectLines")
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
 describe.each`
-	subjectLine                                             | expectedRange
-	${"test"}                                               | ${[0, 1]}
-	${"release the robot butler"}                           | ${[0, 1]}
-	${"  some refactoring "}                                | ${[2, 3]}
-	${"fix this confusing plate of spaghetti"}              | ${[0, 1]}
-	${"never give up!!"}                                    | ${[0, 1]}
-	${"fixup! resolve a bug that thought it was a feature"} | ${[7, 8]}
-	${"squash! make the program act like a clown"}          | ${[8, 9]}
-	${"GH-12 organise the bookshelf."}                      | ${[6, 7]}
-	${"amend! solve the problem!"}                          | ${[7, 8]}
-	${" fix it"}                                            | ${[1, 2]}
-	${"#7 #8 resolve a bug that thought it was a feature"}  | ${[6, 7]}
-	${"amend! GH-55: make the program act like a clown"}    | ${[14, 15]}
-	${"i thought this was a good idea"}                     | ${[0, 1]}
-	${"   wip"}                                             | ${[3, 4]}
+	subjectLine                                                      | expectedRange
+	${"test"}                                                        | ${[0, 1]}
+	${"release the robot butler"}                                    | ${[0, 1]}
+	${"  some refactoring "}                                         | ${[2, 3]}
+	${"fix this confusing plate of spaghetti"}                       | ${[0, 1]}
+	${"never give up!!"}                                             | ${[0, 1]}
+	${"fixup! resolve a bug that thought it was a feature"}          | ${[7, 8]}
+	${"squash! make the program act like a clown"}                   | ${[8, 9]}
+	${"GH-12 organise the bookshelf."}                               | ${[6, 7]}
+	${"amend! solve the problem!"}                                   | ${[7, 8]}
+	${" fix it"}                                                     | ${[1, 2]}
+	${"#7 #8 resolve a bug that thought it was a feature"}           | ${[6, 7]}
+	${"amend! GH-55: make the program act like a clown"}             | ${[14, 15]}
+	${"i thought this was a good idea"}                              | ${[0, 1]}
+	${"   wip"}                                                      | ${[3, 4]}
+	${'revert "fix a nasty bug"'}                                    | ${[0, 1]}
+	${'squash!fixup! revert "Revert "Repair the soft ice machine""'} | ${[14, 15]}
 `(
 	"when the subject line of $subjectLine starts with a lowercase letter",
 	(props: { subjectLine: string; expectedRange: CharacterRange }) => {
@@ -70,6 +72,8 @@ describe.each`
 	${"Resolve issues in #21 to make the code work better"}
 	${"Finally..."}
 	${"Let `SoftIceMachineAdapter` produce the goods that we need"}
+	${'Revert "release the robot butler"'}
+	${'fixup! Revert "Resolve a bug that thought it was a feature"'}
 `(
 	"when the subject line of $subjectLine starts with an uppercase letter",
 	(props: { subjectLine: string }) => {

--- a/src/domains/rules/UseCapitalisedSubjectLines.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.ts
@@ -1,6 +1,5 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
-import type { TextToken } from "#commits/tokens/TextToken.ts"
-import { trimmedTokenRange } from "#commits/tokens/Token.ts"
+import { type Token, trimmedTokenRange } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { type RuleContext, ruleContext } from "#rules/Rule.ts"
@@ -13,7 +12,7 @@ import { notNullish } from "#utilities/Arrays.ts"
  * Standardising the commit message format helps to preserve the readability of the commit history.
  *
  * It ignores commits that do not start with a letter.
- * It disregards issue links, inline code phrases, revert markers, and squash markers.
+ * It disregards issue links, inline code phrases, and squash markers.
  */
 export function useCapitalisedSubjectLines(
 	commits: Commits,
@@ -29,7 +28,7 @@ export function useCapitalisedSubjectLines(
 
 function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 	for (const token of commit.subjectLine) {
-		if (token.type === "text") {
+		if (token.type === "text" || token.type === "revert-marker") {
 			if (startsWithLowercaseLetter(token)) {
 				const [startIndex] = trimmedTokenRange(token)
 
@@ -45,7 +44,7 @@ function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 	return null
 }
 
-function startsWithLowercaseLetter(token: TextToken): boolean {
+function startsWithLowercaseLetter(token: Token): boolean {
 	const firstCharacter = token.value.trimStart()[0] ?? ""
 	return firstCharacter !== firstCharacter.toUpperCase()
 }

--- a/src/domains/rules/UseConciseSubjectLines.tests.ts
+++ b/src/domains/rules/UseConciseSubjectLines.tests.ts
@@ -127,12 +127,11 @@ describe.each`
 
 describe.each`
 	subjectLine                                                                                 | expectedRange20 | expectedRange50
-	${"#510 Fixed a bug, but have probably introduced another one"}                             | ${[25, 58]}     | ${[55, 58]}
+	${"Fixed a bug, but have probably introduced another one #510"}                             | ${[20, 53]}     | ${[50, 53]}
 	${"fixup! forgot to save my changes before entering the merge chaos"}                       | ${[27, 64]}     | ${[57, 64]}
-	${'Revert "retrieve data from the exclusive third-party service"'}                          | ${[28, 60]}     | ${[58, 60]}
 	${"fixup! GH-291 Resolve memory issues to make the code work better than it did last year"} | ${[34, 86]}     | ${[64, 86]}
 `(
-	"when the subject line of $subjectLine contains ignorable tokens and still exceeds 50 characters, but not 72 characters",
+	"when the subject line of $subjectLine contains insignificant tokens and still exceeds 50 characters, but not 72 characters",
 	(props: {
 		subjectLine: string
 		expectedRange20: CharacterRange
@@ -190,10 +189,9 @@ describe.each`
 	${"(GH-72): fix security vulnerability in `BridgeService`"}              | ${[29, 39]}
 	${"Make a smile to the `camera` again"}                                  | ${[28, 34]}
 	${"revisit the glorious `MaxDPS` algorithm"}                             | ${[20, 39]}
-	${'Revert "Revert "Revert "Fix the nasty bug from yesterday"""'}         | ${[44, 56]}
 	${"Squash! Make the program act like a clown"}                           | ${[28, 41]}
 `(
-	"when the subject line of $subjectLine contains ignorable tokens and still exceeds 20 characters, but not 50 characters",
+	"when the subject line of $subjectLine contains insignificant tokens and still exceeds 20 characters, but not 50 characters",
 	(props: { subjectLine: string; expectedRange20: CharacterRange }) => {
 		const commit = fakeCommit({ message: props.subjectLine })
 
@@ -222,6 +220,43 @@ describe.each`
 				expect(actualConcerns).toEqual<Concerns>([])
 			})
 		})
+
+		describe("and the rule is disabled", () => {
+			const actualConcerns = useConciseSubjectLines([commit], null)
+
+			it("does not raise any concerns", () => {
+				expect(actualConcerns).toEqual<Concerns>([])
+			})
+		})
+	},
+)
+
+describe.each`
+	subjectLine
+	${'Revert "bugfix"'}
+	${'Revert "retrieve data from the exclusive third-party service"'}
+	${'Revert "Revert "Revert "Fix the nasty bug from yesterday"""'}
+	${'fixup! Revert "keep the lowercase story around long enough to exceed the limit"'}
+`(
+	"when the subject line of $subjectLine contains a revert marker",
+	(props: { subjectLine: string }) => {
+		const commit = fakeCommit({ message: props.subjectLine })
+
+		describe.each`
+			options
+			${enabled20.options}
+			${enabled50.options}
+			${enabled72.options}
+		`(
+			"and the rule is enabled with a maximum length of $options.maxLength characters",
+			(context: RuleContext<"useConciseSubjectLines">) => {
+				const actualConcerns = useConciseSubjectLines([commit], context.options)
+
+				it("does not raise any concerns", () => {
+					expect(actualConcerns).toEqual<Concerns>([])
+				})
+			},
+		)
 
 		describe("and the rule is disabled", () => {
 			const actualConcerns = useConciseSubjectLines([commit], null)

--- a/src/domains/rules/UseConciseSubjectLines.ts
+++ b/src/domains/rules/UseConciseSubjectLines.ts
@@ -9,8 +9,8 @@ import { notNullish } from "#utilities/Arrays.ts"
  *
  * Keeping the subject line short helps to preserve the readability of the commit history in various Git clients.
  *
- * It ignores merge commits and commits with dependency versions.
- * Issue links, inline code phrases, revert markers, and squash markers do not count towards the limit.
+ * It ignores merge commits, revert commits, and dependency upgrade commits.
+ * Issue links, inline code phrases, and squash markers do not count towards the limit.
  */
 export function useConciseSubjectLines(
 	commits: Commits,
@@ -36,7 +36,7 @@ function verifyCommit(commit: Commit, rule: RuleContext<"useConciseSubjectLines"
 	let overflowEndIndex = 0
 
 	for (const token of commit.subjectLine) {
-		if (token.type === "dependency-version") {
+		if (token.type === "dependency-version" || token.type === "revert-marker") {
 			return null
 		}
 		if (token.type === "text") {

--- a/src/domains/rules/UseImperativeSubjectLines.ts
+++ b/src/domains/rules/UseImperativeSubjectLines.ts
@@ -4,6 +4,9 @@ import { type RuleContext, ruleContext } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
+/**
+ * It ignores revert commits.
+ */
 export function useImperativeSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
 		return []

--- a/src/domains/rules/UseIssueLinks.ts
+++ b/src/domains/rules/UseIssueLinks.ts
@@ -4,6 +4,9 @@ import { type RuleContext, ruleContext } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
+/**
+ * It ignores revert commits.
+ */
 export function useIssueLinks(commits: Commits, options: EmptyObject | null): Concerns {
 	if (options === null) {
 		return []


### PR DESCRIPTION
This commit partially undoes some changes from commit 966ae4b. Unlike a squash commit, which usually refers to a commit on the same branch as itself, a revert commit often refers to a commit that has already been merged to the main branch; hence, it cannot be reworded.

The following rules will now completely ignore revert commits, as it makes little sense to reword the offending commit:

- `noSingleWordSubjectLines`
- `useConciseSubjectLines`

This ignore-behaviour will also apply to these upcoming rules:

- `noUnexpectedPunctuation`
- `noUnexpectedWhitespace`
- `useImperativeSubjectLines`
- `useIssueLinks`

`useCapitalisedSubjectLines` will now apply to the revert marker itself.