### PR TITLE
Use configuration instead of rule context

### DIFF
--- a/src/domains/commits/git/GetGitBranchCrudeCommits.tests.ts
+++ b/src/domains/commits/git/GetGitBranchCrudeCommits.tests.ts
@@ -357,11 +357,7 @@ describe.each`
 		const committerEmail = props.committerEmail
 
 		beforeEach(() => {
-			mockGitLog([
-				{
-					committer: [`${committerName} <${committerEmail}> 1769801867 -0500`],
-				},
-			])
+			mockGitLog([{ committer: [`${committerName} <${committerEmail}> 1769801867 -0500`] }])
 		})
 
 		it("preserves the committer's name", async () => {
@@ -387,11 +383,7 @@ describe.each`
 		const committerEmail = "25199993+noname@users.noreply.github.com"
 
 		beforeEach(() => {
-			mockGitLog([
-				{
-					committer: [`${committerName} <${committerEmail}> 1769801867 -0500`],
-				},
-			])
+			mockGitLog([{ committer: [`${committerName} <${committerEmail}> 1769801867 -0500`] }])
 		})
 
 		it("preserves the committer's name as is", async () => {
@@ -410,11 +402,7 @@ describe.each`
 	const committerEmail = "25199993+noname@users.noreply.github.com"
 
 	beforeEach(() => {
-		mockGitLog([
-			{
-				committer: [`${committerName} <${committerEmail}> 1769801867 -0500`],
-			},
-		])
+		mockGitLog([{ committer: [`${committerName} <${committerEmail}> 1769801867 -0500`] }])
 	})
 
 	it("preserves the committer's name as is", async () => {
@@ -452,11 +440,7 @@ describe.each`
 		const committerEmail = props.committerEmail
 
 		beforeEach(() => {
-			mockGitLog([
-				{
-					committer: [`${committerName} <${committerEmail}> 1769801867 -0500`],
-				},
-			])
+			mockGitLog([{ committer: [`${committerName} <${committerEmail}> 1769801867 -0500`] }])
 		})
 
 		it("preserves the committer's email address as is", async () => {
@@ -477,11 +461,7 @@ describe.each`
 		const committerEmail = props.committerEmail
 
 		beforeEach(() => {
-			mockGitLog([
-				{
-					committer: [`${committerName} <${committerEmail}> 1769801867 -0500`],
-				},
-			])
+			mockGitLog([{ committer: [`${committerName} <${committerEmail}> 1769801867 -0500`] }])
 		})
 
 		it("preserves the committer's email address as is", async () => {

--- a/src/domains/configurations/Configuration.ts
+++ b/src/domains/configurations/Configuration.ts
@@ -9,7 +9,7 @@ export type Configuration = {
  * A record of rule keys to rule-specific options (if the rule is enabled) or null (if the rule is disabled).
  */
 export type RuleConfiguration = {
-	[Key in RuleKey]: RuleOptions<Key>
+	[Key in RuleKey]: RuleOptions<Key> | null
 }
 
 export type TokenConfiguration = {

--- a/src/domains/rules/NoBlankSubjectLines.tests.ts
+++ b/src/domains/rules/NoBlankSubjectLines.tests.ts
@@ -5,11 +5,12 @@ import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noBlankSubjectLines } from "#rules/NoBlankSubjectLines.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled = ruleContext("noBlankSubjectLines")
+const rule = "noBlankSubjectLines" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -25,13 +26,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], enabled.options)
+			const actualConcerns = noBlankSubjectLines([commit], enabled)
 
 			it("raises a concern about the first character in the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, {
-						range: props.expectedRange,
-					}),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -66,13 +65,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], enabled.options)
+			const actualConcerns = noBlankSubjectLines([commit], enabled)
 
 			it("raises a concern about the first character after the insignificant tokens", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, {
-						range: props.expectedRange,
-					}),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -106,7 +103,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.subjectLine })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines([commit], enabled.options)
+		const actualConcerns = noBlankSubjectLines([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -133,13 +130,13 @@ describe("when verifying a set of multiple commits and some commits have blank s
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, enabled.options)
+		const actualConcerns = noBlankSubjectLines(commits, enabled)
 
 		it("raises concerns about the commits with blank subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled, commits[0].sha, { range: [0, 1] }),
-				subjectLineConcern(enabled, commits[1].sha, { range: [3, 4] }),
-				subjectLineConcern(enabled, commits[4].sha, { range: [0, 1] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [0, 1] }),
+				subjectLineConcern(rule, commits[1].sha, { range: [3, 4] }),
+				subjectLineConcern(rule, commits[4].sha, { range: [0, 1] }),
 			])
 		})
 	})
@@ -162,7 +159,7 @@ describe("when verifying a set of multiple commits and no commits have blank sub
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, enabled.options)
+		const actualConcerns = noBlankSubjectLines(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoBlankSubjectLines.ts
+++ b/src/domains/rules/NoBlankSubjectLines.ts
@@ -2,9 +2,11 @@ import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Token } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "noBlankSubjectLines" satisfies RuleKey
 
 /**
  * Verifies that the subject line contains at least one non-whitespace character.
@@ -15,15 +17,10 @@ import { notNullish } from "#utilities/Arrays.ts"
  * Issue links, revert markers, and squash markers do not count as non-whitespace characters.
  */
 export function noBlankSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noBlankSubjectLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
+function verifyCommit(commit: Commit): Concern | null {
 	let lastInsignificantToken: Token | null = null
 
 	for (const token of commit.subjectLine) {
@@ -48,7 +45,5 @@ function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 			? lastInsignificantToken.range[0] + lastInsignificantToken.value.trimEnd().length
 			: 0
 
-	return subjectLineConcern(rule, commit.sha, {
-		range: [firstBlankIndex, firstBlankIndex + 1],
-	})
+	return subjectLineConcern(rule, commit.sha, { range: [firstBlankIndex, firstBlankIndex + 1] })
 }

--- a/src/domains/rules/NoExcessiveCommitsPerBranch.ts
+++ b/src/domains/rules/NoExcessiveCommitsPerBranch.ts
@@ -1,21 +1,20 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "noExcessiveCommitsPerBranch" satisfies RuleKey
 
 export function noExcessiveCommitsPerBranch(
 	commits: Commits,
 	options: EmptyObject | null,
 ): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noExcessiveCommitsPerBranch")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `noExcessiveCommitsPerBranch` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/NoMergeCommits.tests.ts
+++ b/src/domains/rules/NoMergeCommits.tests.ts
@@ -4,11 +4,12 @@ import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { noMergeCommits } from "#rules/NoMergeCommits.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
-const enabled = ruleContext("noMergeCommits")
+const rule = "noMergeCommits" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -24,10 +25,10 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noMergeCommits([commit], enabled.options)
+			const actualConcerns = noMergeCommits([commit], enabled)
 
 			it("raises a concern about the entire commit", () => {
-				expect(actualConcerns).toEqual<Concerns>([commitConcern(enabled, commit.sha)])
+				expect(actualConcerns).toEqual<Concerns>([commitConcern(rule, commit.sha)])
 			})
 		})
 
@@ -53,7 +54,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noMergeCommits([commit], enabled.options)
+			const actualConcerns = noMergeCommits([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoMergeCommits.ts
+++ b/src/domains/rules/NoMergeCommits.ts
@@ -1,9 +1,11 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "noMergeCommits" satisfies RuleKey
 
 /**
  * Verifies that the commit has at most one parent commit, thus disallowing merge commits.
@@ -12,18 +14,9 @@ import { notNullish } from "#utilities/Arrays.ts"
  * This helps to preserve the readability of the commit history and makes it easier to revert changes later.
  */
 export function noMergeCommits(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noMergeCommits")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
-	if (commit.isMergeCommit) {
-		return commitConcern(rule, commit.sha)
-	}
-
-	return null
+function verifyCommit(commit: Commit): Concern | null {
+	return commit.isMergeCommit ? commitConcern(rule, commit.sha) : null
 }

--- a/src/domains/rules/NoRepeatedSubjectLines.ts
+++ b/src/domains/rules/NoRepeatedSubjectLines.ts
@@ -1,18 +1,15 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function noRepeatedSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "noRepeatedSubjectLines" satisfies RuleKey
 
-	const rule = ruleContext("noRepeatedSubjectLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function noRepeatedSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit): Concern | null {
 	throw new Error("The `noRepeatedSubjectLines` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/NoRestrictedFooterLines.ts
+++ b/src/domains/rules/NoRestrictedFooterLines.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function noRestrictedFooterLines(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "noRestrictedFooterLines" satisfies RuleKey
 
-	const rule = ruleContext("noRestrictedFooterLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function noRestrictedFooterLines(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `noRestrictedFooterLines` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/NoRevertRevertCommits.tests.ts
+++ b/src/domains/rules/NoRevertRevertCommits.tests.ts
@@ -5,11 +5,12 @@ import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noRevertRevertCommits } from "#rules/NoRevertRevertCommits.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled = ruleContext("noRevertRevertCommits")
+const rule = "noRevertRevertCommits" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -29,11 +30,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled.options)
+			const actualConcerns = noRevertRevertCommits([commit], enabled)
 
 			it("raises a concern about the revert marker", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -63,7 +64,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled.options)
+			const actualConcerns = noRevertRevertCommits([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -105,7 +106,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled.options)
+			const actualConcerns = noRevertRevertCommits([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -136,14 +137,14 @@ describe("when verifying a set of multiple commits and some commits have revert 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, enabled.options)
+		const actualConcerns = noRevertRevertCommits(commits, enabled)
 
 		it("raises concerns about the commits with double revert markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled, commits[0].sha, { range: [0, 16] }),
-				subjectLineConcern(enabled, commits[3].sha, { range: [8, 24] }),
-				subjectLineConcern(enabled, commits[5].sha, { range: [1, 17] }),
-				subjectLineConcern(enabled, commits[6].sha, { range: [0, 24] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [0, 16] }),
+				subjectLineConcern(rule, commits[3].sha, { range: [8, 24] }),
+				subjectLineConcern(rule, commits[5].sha, { range: [1, 17] }),
+				subjectLineConcern(rule, commits[6].sha, { range: [0, 24] }),
 			])
 		})
 	})
@@ -168,7 +169,7 @@ describe("when verifying a set of multiple commits and no commits have revert ma
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, enabled.options)
+		const actualConcerns = noRevertRevertCommits(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoRevertRevertCommits.ts
+++ b/src/domains/rules/NoRevertRevertCommits.ts
@@ -2,9 +2,11 @@ import type { Commit, Commits } from "#commits/Commit.ts"
 import { trimmedTokenRange } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "noRevertRevertCommits" satisfies RuleKey
 
 /**
  * Verifies that the subject line contains at most one revert marker.
@@ -13,20 +15,13 @@ import { notNullish } from "#utilities/Arrays.ts"
  * This helps to preserve the traceability of the commit history.
  */
 export function noRevertRevertCommits(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noRevertRevertCommits")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
+function verifyCommit(commit: Commit): Concern | null {
 	for (const token of commit.subjectLine) {
 		if (token.type === "revert-marker" && token.occurrences > 1) {
-			return subjectLineConcern(rule, commit.sha, {
-				range: trimmedTokenRange(token),
-			})
+			return subjectLineConcern(rule, commit.sha, { range: trimmedTokenRange(token) })
 		}
 	}
 

--- a/src/domains/rules/NoSingleWordSubjectLines.tests.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.tests.ts
@@ -5,11 +5,12 @@ import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noSingleWordSubjectLines } from "#rules/NoSingleWordSubjectLines.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled = ruleContext("noSingleWordSubjectLines")
+const rule = "noSingleWordSubjectLines" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -45,11 +46,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
+			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
 
 			it("raises a concern about the single word", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -80,7 +81,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
+			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -110,7 +111,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
+			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -147,7 +148,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled.options)
+			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -177,14 +178,14 @@ describe("when verifying a set of multiple commits and some commits have single-
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, enabled.options)
+		const actualConcerns = noSingleWordSubjectLines(commits, enabled)
 
 		it("raises concerns about the commits with single-word subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled, commits[0].sha, { range: [0, 4] }),
-				subjectLineConcern(enabled, commits[1].sha, { range: [0, 5] }),
-				subjectLineConcern(enabled, commits[3].sha, { range: [1, 9] }),
-				subjectLineConcern(enabled, commits[5].sha, { range: [0, 7] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [0, 4] }),
+				subjectLineConcern(rule, commits[1].sha, { range: [0, 5] }),
+				subjectLineConcern(rule, commits[3].sha, { range: [1, 9] }),
+				subjectLineConcern(rule, commits[5].sha, { range: [0, 7] }),
 			])
 		})
 	})
@@ -207,7 +208,7 @@ describe("when verifying a set of multiple commits and no commits have single-wo
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, enabled.options)
+		const actualConcerns = noSingleWordSubjectLines(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoSingleWordSubjectLines.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.ts
@@ -2,9 +2,11 @@ import type { Commit, Commits } from "#commits/Commit.ts"
 import { type Token, trimmedTokenRange } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notEmptyString, notNullish } from "#utilities/Arrays.ts"
+
+const rule = "noSingleWordSubjectLines" satisfies RuleKey
 
 /**
  * Verifies that the subject line contains at least two words.
@@ -16,15 +18,10 @@ import { notEmptyString, notNullish } from "#utilities/Arrays.ts"
  * Leading issue links and squash markers do not count as words.
  */
 export function noSingleWordSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noSingleWordSubjectLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
+function verifyCommit(commit: Commit): Concern | null {
 	let words = 0
 	let firstWordToken: Token | null = null
 
@@ -43,9 +40,7 @@ function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
 	}
 
 	if (words === 1 && firstWordToken !== null) {
-		return subjectLineConcern(rule, commit.sha, {
-			range: trimmedTokenRange(firstWordToken),
-		})
+		return subjectLineConcern(rule, commit.sha, { range: trimmedTokenRange(firstWordToken) })
 	}
 
 	return null

--- a/src/domains/rules/NoSquashMarkers.tests.ts
+++ b/src/domains/rules/NoSquashMarkers.tests.ts
@@ -5,11 +5,12 @@ import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noSquashMarkers } from "#rules/NoSquashMarkers.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled = ruleContext("noSquashMarkers")
+const rule = "noSquashMarkers" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -33,11 +34,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled.options)
+			const actualConcerns = noSquashMarkers([commit], enabled)
 
 			it("raises a concern about the squash marker", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -63,11 +64,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled.options)
+			const actualConcerns = noSquashMarkers([commit], enabled)
 
 			it("raises a concern about all squash markers", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -113,7 +114,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled.options)
+			const actualConcerns = noSquashMarkers([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -142,13 +143,13 @@ describe("when verifying a set of multiple commits and some commits have squash 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSquashMarkers(commits, enabled.options)
+		const actualConcerns = noSquashMarkers(commits, enabled)
 
 		it("raises concerns about the commits with squash markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled, commits[0].sha, { range: [0, 6] }),
-				subjectLineConcern(enabled, commits[1].sha, { range: [0, 7] }),
-				subjectLineConcern(enabled, commits[4].sha, { range: [1, 7] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [0, 6] }),
+				subjectLineConcern(rule, commits[1].sha, { range: [0, 7] }),
+				subjectLineConcern(rule, commits[4].sha, { range: [1, 7] }),
 			])
 		})
 	})
@@ -172,7 +173,7 @@ describe("when verifying a set of multiple commits and no commits have squash ma
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSquashMarkers(commits, enabled.options)
+		const actualConcerns = noSquashMarkers(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoSquashMarkers.ts
+++ b/src/domains/rules/NoSquashMarkers.ts
@@ -2,9 +2,11 @@ import type { Commit, Commits } from "#commits/Commit.ts"
 import { trimmedTokenRange } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "noSquashMarkers" satisfies RuleKey
 
 /**
  * Verifies that the subject line does not contain any squash marker.
@@ -13,22 +15,13 @@ import { notNullish } from "#utilities/Arrays.ts"
  * as it omits unnecessary diffs and increases the cohesion of commits. It also makes it easier to revert changes later.
  */
 export function noSquashMarkers(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noSquashMarkers")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
+function verifyCommit(commit: Commit): Concern | null {
 	const [firstToken] = commit.subjectLine
 
-	if (firstToken?.type === "squash-marker") {
-		return subjectLineConcern(rule, commit.sha, {
-			range: trimmedTokenRange(firstToken),
-		})
-	}
-
-	return null
+	return firstToken?.type === "squash-marker"
+		? subjectLineConcern(rule, commit.sha, { range: trimmedTokenRange(firstToken) })
+		: null
 }

--- a/src/domains/rules/NoUnexpectedPunctuation.ts
+++ b/src/domains/rules/NoUnexpectedPunctuation.ts
@@ -1,21 +1,20 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "noUnexpectedPunctuation" satisfies RuleKey
 
 /**
  * It ignores revert commits.
  */
 export function noUnexpectedPunctuation(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noUnexpectedPunctuation")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `noUnexpectedPunctuation` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/NoUnexpectedWhitespace.ts
+++ b/src/domains/rules/NoUnexpectedWhitespace.ts
@@ -1,21 +1,18 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "noUnexpectedWhitespace" satisfies RuleKey
 
 /**
  * It ignores revert commits.
  */
 export function noUnexpectedWhitespace(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("noUnexpectedWhitespace")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit): Concern | null {
 	throw new Error("The `noUnexpectedWhitespace` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/Rule.ts
+++ b/src/domains/rules/Rule.ts
@@ -19,7 +19,6 @@ import type { useImperativeSubjectLines } from "#rules/UseImperativeSubjectLines
 import type { useIssueLinks } from "#rules/UseIssueLinks.ts"
 import type { useLineWrapping } from "#rules/UseLineWrapping.ts"
 import type { useSignedCommits } from "#rules/UseSignedCommits.ts"
-import type { EmptyObject } from "#types/EmptyObject.ts"
 
 export type RulesByKey = {
 	noBlankSubjectLines: typeof noBlankSubjectLines
@@ -47,19 +46,4 @@ export type RulesByKey = {
 
 export type RuleKey = keyof RulesByKey
 
-export type RuleContext<Key extends RuleKey = RuleKey> = {
-	[K in RuleKey]: {
-		key: K
-		options: NonNullable<RuleOptions<K>>
-	}
-}[Key]
-
-export function ruleContext<Key extends RuleKey>(
-	key: Key,
-	// Disallow the `options` parameter if the rule does not take any options.
-	...options: NonNullable<RuleOptions<Key>> extends EmptyObject ? [never?] : [RuleOptions<Key>]
-): { key: Key; options: NonNullable<RuleOptions<Key>> } {
-	return { key, options: options[0] ?? {} }
-}
-
-export type RuleOptions<Key extends RuleKey> = Parameters<RulesByKey[Key]>[1]
+export type RuleOptions<Key extends RuleKey> = NonNullable<Parameters<RulesByKey[Key]>[1]>

--- a/src/domains/rules/UseAuthorEmailPatterns.ts
+++ b/src/domains/rules/UseAuthorEmailPatterns.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useAuthorEmailPatterns(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useAuthorEmailPatterns" satisfies RuleKey
 
-	const rule = ruleContext("useAuthorEmailPatterns")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useAuthorEmailPatterns(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useAuthorEmailPatterns` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseAuthorNamePatterns.ts
+++ b/src/domains/rules/UseAuthorNamePatterns.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useAuthorNamePatterns(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useAuthorNamePatterns" satisfies RuleKey
 
-	const rule = ruleContext("useAuthorNamePatterns")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useAuthorNamePatterns(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useAuthorNamePatterns` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
@@ -4,12 +4,13 @@ import type { Commit } from "#commits/Commit.ts"
 import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import { useCapitalisedSubjectLines } from "#rules/UseCapitalisedSubjectLines.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled = ruleContext("useCapitalisedSubjectLines")
+const rule = "useCapitalisedSubjectLines" satisfies RuleKey
+const enabled: RuleOptions<typeof rule> = {}
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -37,11 +38,11 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled.options)
+			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
 
 			it("raises a concern about the first non-capitalised character", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled, commit.sha, { range: props.expectedRange }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange }),
 				])
 			})
 		})
@@ -80,7 +81,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled.options)
+			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -111,7 +112,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled.options)
+			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -139,7 +140,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.subjectLine })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines([commit], enabled.options)
+		const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -169,13 +170,13 @@ describe("when verifying a set of multiple commits and some commits have non-cap
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, enabled.options)
+		const actualConcerns = useCapitalisedSubjectLines(commits, enabled)
 
 		it("raises concerns about the commits with non-capitalised subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled, commits[0].sha, { range: [0, 1] }),
-				subjectLineConcern(enabled, commits[3].sha, { range: [0, 1] }),
-				subjectLineConcern(enabled, commits[5].sha, { range: [7, 8] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [0, 1] }),
+				subjectLineConcern(rule, commits[3].sha, { range: [0, 1] }),
+				subjectLineConcern(rule, commits[5].sha, { range: [7, 8] }),
 			])
 		})
 	})
@@ -198,7 +199,7 @@ describe("when verifying a set of multiple commits and all commits have capitali
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, enabled.options)
+		const actualConcerns = useCapitalisedSubjectLines(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseCapitalisedSubjectLines.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.ts
@@ -2,9 +2,11 @@ import type { Commit, Commits } from "#commits/Commit.ts"
 import { type Token, trimmedTokenRange } from "#commits/tokens/Token.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "useCapitalisedSubjectLines" satisfies RuleKey
 
 /**
  * Verifies that the subject line starts with an uppercase letter.
@@ -18,23 +20,15 @@ export function useCapitalisedSubjectLines(
 	commits: Commits,
 	options: EmptyObject | null,
 ): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("useCapitalisedSubjectLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext): Concern | null {
+function verifyCommit(commit: Commit): Concern | null {
 	for (const token of commit.subjectLine) {
 		if (token.type === "text" || token.type === "revert-marker") {
 			if (startsWithLowercaseLetter(token)) {
 				const [startIndex] = trimmedTokenRange(token)
-
-				return subjectLineConcern(rule, commit.sha, {
-					range: [startIndex, startIndex + 1],
-				})
+				return subjectLineConcern(rule, commit.sha, { range: [startIndex, startIndex + 1] })
 			}
 
 			return null

--- a/src/domains/rules/UseCommitterEmailPatterns.ts
+++ b/src/domains/rules/UseCommitterEmailPatterns.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useCommitterEmailPatterns(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useCommitterEmailPatterns" satisfies RuleKey
 
-	const rule = ruleContext("useCommitterEmailPatterns")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useCommitterEmailPatterns(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useCommitterEmailPatterns` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseCommitterNamePatterns.ts
+++ b/src/domains/rules/UseCommitterNamePatterns.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useCommitterNamePatterns(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useCommitterNamePatterns" satisfies RuleKey
 
-	const rule = ruleContext("useCommitterNamePatterns")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useCommitterNamePatterns(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useCommitterNamePatterns` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseConciseSubjectLines.tests.ts
+++ b/src/domains/rules/UseConciseSubjectLines.tests.ts
@@ -4,16 +4,17 @@ import type { Commit } from "#commits/Commit.ts"
 import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import { useConciseSubjectLines } from "#rules/UseConciseSubjectLines.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const enabled20 = ruleContext("useConciseSubjectLines", { maxLength: 20 })
-const enabled50 = ruleContext("useConciseSubjectLines", { maxLength: 50 })
-const enabled72 = ruleContext("useConciseSubjectLines", { maxLength: 72 })
+const rule = "useConciseSubjectLines" satisfies RuleKey
+const enabled20: RuleOptions<typeof rule> = { maxLength: 20 }
+const enabled50: RuleOptions<typeof rule> = { maxLength: 50 }
+const enabled72: RuleOptions<typeof rule> = { maxLength: 72 }
 
 const fakeCommit = fakeCommitFactory(fakeConfiguration())
 
@@ -33,31 +34,31 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled20, commit.sha, { range: props.expectedRange20 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange20 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled50, commit.sha, { range: props.expectedRange50 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange50 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled72)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled72, commit.sha, { range: props.expectedRange72 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange72 }),
 				])
 			})
 		})
@@ -88,27 +89,27 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled20, commit.sha, { range: props.expectedRange20 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange20 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled50, commit.sha, { range: props.expectedRange50 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange50 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -140,27 +141,27 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled20, commit.sha, { range: props.expectedRange20 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange20 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled50, commit.sha, { range: props.expectedRange50 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange50 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -196,17 +197,17 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
-					subjectLineConcern(enabled20, commit.sha, { range: props.expectedRange20 }),
+					subjectLineConcern(rule, commit.sha, { range: props.expectedRange20 }),
 				])
 			})
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled50)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -214,7 +215,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72.options)
+			const actualConcerns = useConciseSubjectLines([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -244,13 +245,13 @@ describe.each`
 
 		describe.each`
 			options
-			${enabled20.options}
-			${enabled50.options}
-			${enabled72.options}
+			${enabled20}
+			${enabled50}
+			${enabled72}
 		`(
 			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(context: RuleContext<"useConciseSubjectLines">) => {
-				const actualConcerns = useConciseSubjectLines([commit], context.options)
+			(options: RuleOptions<typeof rule>) => {
+				const actualConcerns = useConciseSubjectLines([commit], options)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -279,13 +280,13 @@ describe.each`
 
 		describe.each`
 			options
-			${enabled20.options}
-			${enabled50.options}
-			${enabled72.options}
+			${enabled20}
+			${enabled50}
+			${enabled72}
 		`(
 			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(context: RuleContext<"useConciseSubjectLines">) => {
-				const actualConcerns = useConciseSubjectLines([commit], context.options)
+			(options: RuleOptions<typeof rule>) => {
+				const actualConcerns = useConciseSubjectLines([commit], options)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -320,13 +321,13 @@ describe.each`
 
 		describe.each`
 			options
-			${enabled20.options}
-			${enabled50.options}
-			${enabled72.options}
+			${enabled20}
+			${enabled50}
+			${enabled72}
 		`(
 			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(context: RuleContext<"useConciseSubjectLines">) => {
-				const actualConcerns = useConciseSubjectLines([commit], context.options)
+			(options: RuleOptions<typeof rule>) => {
+				const actualConcerns = useConciseSubjectLines([commit], options)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -370,42 +371,42 @@ describe("when verifying a set of multiple commits and some commits have long su
 	]
 
 	describe("and the rule is enabled with a maximum length of 20 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled20.options)
+		const actualConcerns = useConciseSubjectLines(commits, enabled20)
 
 		it("raises concerns about the commits whose subject lines exceed 20 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled20, commits[0].sha, { range: [20, 52] }),
-				subjectLineConcern(enabled20, commits[1].sha, { range: [20, 24] }),
-				subjectLineConcern(enabled20, commits[3].sha, { range: [20, 67] }),
-				subjectLineConcern(enabled20, commits[5].sha, { range: [25, 33] }),
-				subjectLineConcern(enabled20, commits[7].sha, { range: [20, 75] }),
-				subjectLineConcern(enabled20, commits[8].sha, { range: [20, 28] }),
-				subjectLineConcern(enabled20, commits[9].sha, { range: [27, 35] }),
-				subjectLineConcern(enabled20, commits[10].sha, { range: [89, 99] }),
-				subjectLineConcern(enabled20, commits[11].sha, { range: [20, 76] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [20, 52] }),
+				subjectLineConcern(rule, commits[1].sha, { range: [20, 24] }),
+				subjectLineConcern(rule, commits[3].sha, { range: [20, 67] }),
+				subjectLineConcern(rule, commits[5].sha, { range: [25, 33] }),
+				subjectLineConcern(rule, commits[7].sha, { range: [20, 75] }),
+				subjectLineConcern(rule, commits[8].sha, { range: [20, 28] }),
+				subjectLineConcern(rule, commits[9].sha, { range: [27, 35] }),
+				subjectLineConcern(rule, commits[10].sha, { range: [89, 99] }),
+				subjectLineConcern(rule, commits[11].sha, { range: [20, 76] }),
 			])
 		})
 	})
 
 	describe("and the rule is enabled with a maximum length of 50 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled50.options)
+		const actualConcerns = useConciseSubjectLines(commits, enabled50)
 
 		it("raises concerns about the commits whose subject lines exceed 50 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled50, commits[0].sha, { range: [50, 52] }),
-				subjectLineConcern(enabled50, commits[7].sha, { range: [50, 75] }),
-				subjectLineConcern(enabled50, commits[11].sha, { range: [50, 76] }),
+				subjectLineConcern(rule, commits[0].sha, { range: [50, 52] }),
+				subjectLineConcern(rule, commits[7].sha, { range: [50, 75] }),
+				subjectLineConcern(rule, commits[11].sha, { range: [50, 76] }),
 			])
 		})
 	})
 
 	describe("and the rule is enabled with a maximum length of 72 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled72.options)
+		const actualConcerns = useConciseSubjectLines(commits, enabled72)
 
 		it("raises concerns about the commits whose subject lines exceed 72 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
-				subjectLineConcern(enabled72, commits[7].sha, { range: [72, 75] }),
-				subjectLineConcern(enabled72, commits[11].sha, { range: [72, 76] }),
+				subjectLineConcern(rule, commits[7].sha, { range: [72, 75] }),
+				subjectLineConcern(rule, commits[11].sha, { range: [72, 76] }),
 			])
 		})
 	})
@@ -429,13 +430,13 @@ describe("when verifying a set of multiple commits and all commits have concise 
 
 	describe.each`
 		options
-		${enabled20.options}
-		${enabled50.options}
-		${enabled72.options}
+		${enabled20}
+		${enabled50}
+		${enabled72}
 	`(
 		"and the rule is enabled with a maximum length of $options.maxLength characters",
-		(context: RuleContext<"useConciseSubjectLines">) => {
-			const actualConcerns = useConciseSubjectLines(commits, context.options)
+		(options: RuleOptions<typeof rule>) => {
+			const actualConcerns = useConciseSubjectLines(commits, options)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseConciseSubjectLines.ts
+++ b/src/domains/rules/UseConciseSubjectLines.ts
@@ -1,8 +1,10 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const rule = "useConciseSubjectLines" satisfies RuleKey
 
 /**
  * Verifies that the subject line does not exceed a given number of characters (default: 50 characters).
@@ -16,20 +18,17 @@ export function useConciseSubjectLines(
 	commits: Commits,
 	options: { maxLength: number } | null,
 ): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("useConciseSubjectLines", options)
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(commit: Commit, rule: RuleContext<"useConciseSubjectLines">): Concern | null {
+function verifyCommit(commit: Commit, options: RuleOptions<typeof rule>): Concern | null {
 	if (commit.isMergeCommit) {
 		return null
 	}
 
-	const maxLength = rule.options.maxLength
+	const maxLength = options.maxLength
 
 	let textLength = 0
 	let overflowStartIndex = 0
@@ -52,11 +51,7 @@ function verifyCommit(commit: Commit, rule: RuleContext<"useConciseSubjectLines"
 		}
 	}
 
-	if (overflowEndIndex !== overflowStartIndex) {
-		return subjectLineConcern(rule, commit.sha, {
-			range: [overflowStartIndex, overflowEndIndex],
-		})
-	}
-
-	return null
+	return overflowEndIndex !== overflowStartIndex
+		? subjectLineConcern(rule, commit.sha, { range: [overflowStartIndex, overflowEndIndex] })
+		: null
 }

--- a/src/domains/rules/UseEmptyLineBeforeBodyLines.ts
+++ b/src/domains/rules/UseEmptyLineBeforeBodyLines.ts
@@ -1,21 +1,18 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "useEmptyLineBeforeBodyLines" satisfies RuleKey
 
 export function useEmptyLineBeforeBodyLines(
 	commits: Commits,
 	options: EmptyObject | null,
 ): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("useEmptyLineBeforeBodyLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit): Concern | null {
 	throw new Error("The `useEmptyLineBeforeBodyLines` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseImperativeSubjectLines.ts
+++ b/src/domains/rules/UseImperativeSubjectLines.ts
@@ -1,21 +1,20 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "useImperativeSubjectLines" satisfies RuleKey
 
 /**
  * It ignores revert commits.
  */
 export function useImperativeSubjectLines(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("useImperativeSubjectLines")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useImperativeSubjectLines` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseIssueLinks.ts
+++ b/src/domains/rules/UseIssueLinks.ts
@@ -1,21 +1,20 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
+
+const _rule = "useIssueLinks" satisfies RuleKey
 
 /**
  * It ignores revert commits.
  */
 export function useIssueLinks(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
-
-	const rule = ruleContext("useIssueLinks")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useIssueLinks` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseLineWrapping.ts
+++ b/src/domains/rules/UseLineWrapping.ts
@@ -1,18 +1,17 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useLineWrapping(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useLineWrapping" satisfies RuleKey
 
-	const rule = ruleContext("useLineWrapping")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useLineWrapping(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null
+		? commits.map((commit) => verifyCommit(commit, options)).filter(notNullish)
+		: []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit, _options: RuleOptions<typeof _rule>): Concern | null {
 	throw new Error("The `useLineWrapping` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/UseSignedCommits.ts
+++ b/src/domains/rules/UseSignedCommits.ts
@@ -1,18 +1,15 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import type { Concern, Concerns } from "#rules/concerns/Concern.ts"
-import { type RuleContext, ruleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { EmptyObject } from "#types/EmptyObject.ts"
 import { notNullish } from "#utilities/Arrays.ts"
 
-export function useSignedCommits(commits: Commits, options: EmptyObject | null): Concerns {
-	if (options === null) {
-		return []
-	}
+const _rule = "useSignedCommits" satisfies RuleKey
 
-	const rule = ruleContext("useSignedCommits")
-	return commits.map((commit) => verifyCommit(commit, rule)).filter(notNullish)
+export function useSignedCommits(commits: Commits, options: EmptyObject | null): Concerns {
+	return options !== null ? commits.map(verifyCommit).filter(notNullish) : []
 }
 
-function verifyCommit(_commit: Commit, _rule: RuleContext): Concern | null {
+function verifyCommit(_commit: Commit): Concern | null {
 	throw new Error("The `useSignedCommits` rule has not been implemented yet") // TODO: To be implemented.
 }

--- a/src/domains/rules/concerns/AuthorEmailAddressConcern.ts
+++ b/src/domains/rules/concerns/AuthorEmailAddressConcern.ts
@@ -1,16 +1,16 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type AuthorEmailAddressConcern = {
 	location: "author-email-address"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
 export function authorEmailAddressConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<AuthorEmailAddressConcern, "range">,
 ): AuthorEmailAddressConcern {

--- a/src/domains/rules/concerns/AuthorNameConcern.ts
+++ b/src/domains/rules/concerns/AuthorNameConcern.ts
@@ -1,16 +1,16 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type AuthorNameConcern = {
 	location: "author-name"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
 export function authorNameConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<AuthorNameConcern, "range">,
 ): AuthorNameConcern {

--- a/src/domains/rules/concerns/BodyLineConcern.ts
+++ b/src/domains/rules/concerns/BodyLineConcern.ts
@@ -1,17 +1,17 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type BodyLineConcern = {
 	location: "body-line"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	line: number
 	range: CharacterRange
 }
 
 export function bodyLineConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<BodyLineConcern, "line" | "range">,
 ): BodyLineConcern {

--- a/src/domains/rules/concerns/CommitConcern.ts
+++ b/src/domains/rules/concerns/CommitConcern.ts
@@ -1,12 +1,12 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type CommitConcern = {
 	location: "commit"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 }
 
-export function commitConcern(rule: RuleContext, commitSha: CommitSha): CommitConcern {
+export function commitConcern(rule: RuleKey, commitSha: CommitSha): CommitConcern {
 	return { location: "commit", rule, commitSha }
 }

--- a/src/domains/rules/concerns/CommitterEmailAddressConcern.ts
+++ b/src/domains/rules/concerns/CommitterEmailAddressConcern.ts
@@ -1,16 +1,16 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type CommitterEmailAddressConcern = {
 	location: "committer-email-address"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
 export function committerEmailAddressConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<CommitterEmailAddressConcern, "range">,
 ): CommitterEmailAddressConcern {

--- a/src/domains/rules/concerns/CommitterNameConcern.ts
+++ b/src/domains/rules/concerns/CommitterNameConcern.ts
@@ -1,16 +1,16 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type CommitterNameConcern = {
 	location: "committer-name"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
 export function committerNameConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<CommitterNameConcern, "range">,
 ): CommitterNameConcern {

--- a/src/domains/rules/concerns/SubjectLineConcern.ts
+++ b/src/domains/rules/concerns/SubjectLineConcern.ts
@@ -1,16 +1,16 @@
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type SubjectLineConcern = {
 	location: "subject-line"
-	rule: RuleContext
+	rule: RuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
 export function subjectLineConcern(
-	rule: RuleContext,
+	rule: RuleKey,
 	commitSha: CommitSha,
 	props: Pick<SubjectLineConcern, "range">,
 ): SubjectLineConcern {

--- a/src/domains/rules/reports/CommitwiseReport.tests.ts
+++ b/src/domains/rules/reports/CommitwiseReport.tests.ts
@@ -6,33 +6,33 @@ import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { commitwiseReport } from "#rules/reports/CommitwiseReport.ts"
-import { ruleContext } from "#rules/Rule.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { Vector } from "#types/Vector.ts"
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
-
 describe("when there are no concerns", () => {
+	const configuration = fakeConfiguration()
+
 	const commits: Commits = []
 	const concerns: Concerns = []
 
 	it("is empty", () => {
-		const actualReport = commitwiseReport(commits, concerns)
+		const actualReport = commitwiseReport(concerns, commits, configuration)
 		expect(actualReport).toBe("")
 	})
 })
 
 describe("when 'noBlankSubjectLines' has a concern about characters 0-1 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "52f07a2d665e6d3b3b50b8fca2af298c100ac804c",
 		message: "",
 	})
-	const concern = subjectLineConcern(ruleContext("noBlankSubjectLines"), commit.sha, {
-		range: [0, 1],
-	})
+	const concern = subjectLineConcern("noBlankSubjectLines", commit.sha, { range: [0, 1] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 52f07a2 
@@ -45,16 +45,17 @@ describe("when 'noBlankSubjectLines' has a concern about characters 0-1 of the s
 })
 
 describe("when 'noBlankSubjectLines' has a concern about characters 15-16 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "2ba57d6e3490324db1bacf22ae288481357ef5c",
 		message: 'amend! Revert " "',
 	})
-	const concern = subjectLineConcern(ruleContext("noBlankSubjectLines"), commit.sha, {
-		range: [15, 16],
-	})
+	const concern = subjectLineConcern("noBlankSubjectLines", commit.sha, { range: [15, 16] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 2ba57d6 amend! Revert " "
@@ -67,15 +68,18 @@ describe("when 'noBlankSubjectLines' has a concern about characters 15-16 of the
 })
 
 describe("when 'noMergeCommits' has a concern about the commit", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "507c835ff93e38ed1540ff58fb72f7837f9af13",
 		parents: [fakeCommitSha(), fakeCommitSha()],
 		message: "Merge branch 'main' into bugfix/dance-party-playlist",
 	})
-	const concern = commitConcern(ruleContext("noMergeCommits"), commit.sha)
+	const concern = commitConcern("noMergeCommits", commit.sha)
 
 	it("describes the rule violation", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 507c835 Merge branch 'main' into bugfix/dance-party-playlist
@@ -88,15 +92,18 @@ describe("when 'noMergeCommits' has a concern about the commit", () => {
 })
 
 describe("when 'noMergeCommits' has a concern about the commit", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "71516e17c94c69de4eeafff60fac072764d2",
 		parents: [fakeCommitSha(), fakeCommitSha(), fakeCommitSha()],
 		message: "amend! Merge branch 'feature/new-coffee-machine' into feature/office-overhaul",
 	})
-	const concern = commitConcern(ruleContext("noMergeCommits"), commit.sha)
+	const concern = commitConcern("noMergeCommits", commit.sha)
 
 	it("describes the rule violation", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 71516e1 amend! Merge branch 'feature/new-coffee-machine' into feature/office-overhaul
@@ -109,16 +116,17 @@ describe("when 'noMergeCommits' has a concern about the commit", () => {
 })
 
 describe("when 'noRevertRevertCommits' has a concern about characters 0-16 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "d4e7a978cea34b727ea52f90c928fd535e4aee",
 		message: 'Revert "Revert "Make the program act like a clown""',
 	})
-	const concern = subjectLineConcern(ruleContext("noRevertRevertCommits"), commit.sha, {
-		range: [0, 16],
-	})
+	const concern = subjectLineConcern("noRevertRevertCommits", commit.sha, { range: [0, 16] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 d4e7a97 Revert "Revert "Make the program act like a clown""
@@ -131,16 +139,17 @@ d4e7a97 Revert "Revert "Make the program act like a clown""
 })
 
 describe("when 'noRevertRevertCommits' has a concern about characters 1-26 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "34aa41b818c40682cabeecd5623dfe51df7a4a5",
 		message: ' revert "revert  "revert "repair the soft ice machine """',
 	})
-	const concern = subjectLineConcern(ruleContext("noRevertRevertCommits"), commit.sha, {
-		range: [1, 26],
-	})
+	const concern = subjectLineConcern("noRevertRevertCommits", commit.sha, { range: [1, 26] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 34aa41b  revert "revert  "revert "repair the soft ice machine """
@@ -153,16 +162,17 @@ describe("when 'noRevertRevertCommits' has a concern about characters 1-26 of th
 })
 
 describe("when 'noSingleWordSubjectLines' has a concern about characters 0-3 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "964bce7ef85bb4347a0882c5d43c8cece4938f",
 		message: "WIP",
 	})
-	const concern = subjectLineConcern(ruleContext("noSingleWordSubjectLines"), commit.sha, {
-		range: [0, 3],
-	})
+	const concern = subjectLineConcern("noSingleWordSubjectLines", commit.sha, { range: [0, 3] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 964bce7 WIP
@@ -175,16 +185,17 @@ describe("when 'noSingleWordSubjectLines' has a concern about characters 0-3 of 
 })
 
 describe("when 'noSingleWordSubjectLines' has a concern about characters 11-17 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "a4b6d0e1aee11f7bc39dfd68858257e236256fbf",
 		message: "fixup! #17 bugfix",
 	})
-	const concern = subjectLineConcern(ruleContext("noSingleWordSubjectLines"), commit.sha, {
-		range: [11, 17],
-	})
+	const concern = subjectLineConcern("noSingleWordSubjectLines", commit.sha, { range: [11, 17] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 a4b6d0e fixup! #17 bugfix
@@ -197,14 +208,17 @@ a4b6d0e fixup! #17 bugfix
 })
 
 describe("when 'noSquashMarkers' has a concern about characters 0-6 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "ffebad193fe7d02aa9b19b70ee132a26f14f8caf",
 		message: "amend!Apply strawberry jam to make the code sweeter",
 	})
-	const concern = subjectLineConcern(ruleContext("noSquashMarkers"), commit.sha, { range: [0, 6] })
+	const concern = subjectLineConcern("noSquashMarkers", commit.sha, { range: [0, 6] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 ffebad1 amend!Apply strawberry jam to make the code sweeter
@@ -217,16 +231,17 @@ ffebad1 amend!Apply strawberry jam to make the code sweeter
 })
 
 describe("when 'noSquashMarkers' has a concern about characters 1-14 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "56c750b0811fbcad2b237b2b99fc7d3fc91b926",
 		message: " fixup! fixup! found a funny easter egg",
 	})
-	const concern = subjectLineConcern(ruleContext("noSquashMarkers"), commit.sha, {
-		range: [1, 14],
-	})
+	const concern = subjectLineConcern("noSquashMarkers", commit.sha, { range: [1, 14] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 56c750b  fixup! fixup! found a funny easter egg
@@ -239,16 +254,17 @@ describe("when 'noSquashMarkers' has a concern about characters 1-14 of the subj
 })
 
 describe("when 'useCapitalisedSubjectLines' has a concern about characters 0-1 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "497de39943643a56f7a69d3d19723e3035318644",
 		message: "release the robot butler",
 	})
-	const concern = subjectLineConcern(ruleContext("useCapitalisedSubjectLines"), commit.sha, {
-		range: [0, 1],
-	})
+	const concern = subjectLineConcern("useCapitalisedSubjectLines", commit.sha, { range: [0, 1] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 497de39 release the robot butler
@@ -261,16 +277,17 @@ describe("when 'useCapitalisedSubjectLines' has a concern about characters 0-1 o
 })
 
 describe("when 'useCapitalisedSubjectLines' has a concern about characters 7-8 of the subject line", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "92d6b11650c6b63d64fd77522241b7f50ff5b",
 		message: "fixup! resolve a bug that thought it was a feature",
 	})
-	const concern = subjectLineConcern(ruleContext("useCapitalisedSubjectLines"), commit.sha, {
-		range: [7, 8],
-	})
+	const concern = subjectLineConcern("useCapitalisedSubjectLines", commit.sha, { range: [7, 8] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 92d6b11 fixup! resolve a bug that thought it was a feature
@@ -283,18 +300,19 @@ describe("when 'useCapitalisedSubjectLines' has a concern about characters 7-8 o
 })
 
 describe("when 'useConciseSubjectLines' has a concern about characters 20-25 of the subject line", () => {
+	const configuration = fakeConfiguration({
+		rules: { useConciseSubjectLines: { maxLength: 20 } },
+	})
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "68e921648c4a19e93d72f42a5d39c3eba704e41",
 		message: "Remove redundant call to `wrapper`",
 	})
-	const concern = subjectLineConcern(
-		ruleContext("useConciseSubjectLines", { maxLength: 20 }),
-		commit.sha,
-		{ range: [20, 25] },
-	)
+	const concern = subjectLineConcern("useConciseSubjectLines", commit.sha, { range: [20, 25] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 68e9216 Remove redundant call to \`wrapper\`
@@ -307,18 +325,19 @@ describe("when 'useConciseSubjectLines' has a concern about characters 20-25 of 
 })
 
 describe("when 'useConciseSubjectLines' has a concern about characters 20-67 of the subject line", () => {
+	const configuration = fakeConfiguration({
+		rules: { useConciseSubjectLines: { maxLength: 20 } },
+	})
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "9bed522bd48f0aee7574635bb23f5decdc4999",
 		message: "revisit the boolean properties in the `IceCreamMachine` constructor",
 	})
-	const concern = subjectLineConcern(
-		ruleContext("useConciseSubjectLines", { maxLength: 20 }),
-		commit.sha,
-		{ range: [20, 67] },
-	)
+	const concern = subjectLineConcern("useConciseSubjectLines", commit.sha, { range: [20, 67] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 9bed522 revisit the boolean properties in the \`IceCreamMachine\` constructor
@@ -331,18 +350,19 @@ describe("when 'useConciseSubjectLines' has a concern about characters 20-67 of 
 })
 
 describe("when 'useConciseSubjectLines' has a concern about characters 50-52 of the subject line", () => {
+	const configuration = fakeConfiguration({
+		rules: { useConciseSubjectLines: { maxLength: 50 } },
+	})
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "e8c95d69587a51685070837aaf3a8746e3cbba8",
 		message: "Retrieve data from the exclusive third-party service",
 	})
-	const concern = subjectLineConcern(
-		ruleContext("useConciseSubjectLines", { maxLength: 50 }),
-		commit.sha,
-		{ range: [50, 52] },
-	)
+	const concern = subjectLineConcern("useConciseSubjectLines", commit.sha, { range: [50, 52] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 e8c95d6 Retrieve data from the exclusive third-party service
@@ -355,18 +375,19 @@ e8c95d6 Retrieve data from the exclusive third-party service
 })
 
 describe("when 'useConciseSubjectLines' has a concern about characters 72-76 of the subject line", () => {
+	const configuration = fakeConfiguration({
+		rules: { useConciseSubjectLines: { maxLength: 72 } },
+	})
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commit = fakeCommit({
 		sha: "be86674322213fb408d176589fadbcd44a2df",
 		message: "make a genuine attempt to fix the bugs that the users were complaining about",
 	})
-	const concern = subjectLineConcern(
-		ruleContext("useConciseSubjectLines", { maxLength: 72 }),
-		commit.sha,
-		{ range: [72, 76] },
-	)
+	const concern = subjectLineConcern("useConciseSubjectLines", commit.sha, { range: [72, 76] })
 
 	it("describes the rule violation in the subject line", () => {
-		const actualOutput = commitwiseReport([commit], [concern])
+		const actualOutput = commitwiseReport([concern], [commit], configuration)
 		expect(actualOutput).toBe(
 			`
 be86674 make a genuine attempt to fix the bugs that the users were complaining about
@@ -379,11 +400,14 @@ be86674 make a genuine attempt to fix the bugs that the users were complaining a
 })
 
 describe.todo("when there are multiple concerns of different types", () => {
+	const configuration = fakeConfiguration()
+	const fakeCommit = fakeCommitFactory(configuration)
+
 	const commits: Vector<Commit, 3> = [fakeCommit(), fakeCommit(), fakeCommit()]
 	const concerns: Concerns = []
 
 	it("describes all rule violations, grouped by their commits", () => {
-		const actualOutput = commitwiseReport(commits, concerns)
+		const actualOutput = commitwiseReport(concerns, commits, configuration)
 		expect(actualOutput).toBe("TODO")
 	})
 })

--- a/src/domains/rules/reports/CommitwiseReport.ts
+++ b/src/domains/rules/reports/CommitwiseReport.ts
@@ -1,19 +1,25 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
 import { formatTokenisedLine } from "#commits/tokens/Token.ts"
+import type { Configuration } from "#configurations/Configuration.ts"
 import type { CommitConcern } from "#rules/concerns/CommitConcern.ts"
 import { type Concern, type Concerns, concernedCommit } from "#rules/concerns/Concern.ts"
 import type { SubjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import type { RuleContext } from "#rules/Rule.ts"
+import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 import { formatCharacterRange } from "#types/CharacterRange.ts"
+import { requireNotNullish } from "#utilities/Assertions.ts"
 import { indentString } from "#utilities/Strings.ts"
 
-export function commitwiseReport(commits: Commits, concerns: Concerns): string {
+export function commitwiseReport(
+	concerns: Concerns,
+	commits: Commits,
+	configuration: Configuration,
+): string {
 	return concerns
-		.map((concern) => formatConcern(concern, concernedCommit(concern, commits)))
+		.map((concern) => formatConcern(concern, concernedCommit(concern, commits), configuration))
 		.join("\n\n")
 }
 
-function formatConcern(concern: Concern, commit: Commit): string {
+function formatConcern(concern: Concern, commit: Commit, configuration: Configuration): string {
 	switch (concern.location) {
 		case "author-email-address": {
 			throw new Error(`Not implemented yet: ${concern.location}`)
@@ -25,7 +31,7 @@ function formatConcern(concern: Concern, commit: Commit): string {
 			throw new Error(`Not implemented yet: ${concern.location}`)
 		}
 		case "commit": {
-			return formatCommitConcern(concern, commit)
+			return formatCommitConcern(concern, commit, configuration)
 		}
 		case "committer-email-address": {
 			throw new Error(`Not implemented yet: ${concern.location}`)
@@ -34,7 +40,7 @@ function formatConcern(concern: Concern, commit: Commit): string {
 			throw new Error(`Not implemented yet: ${concern.location}`)
 		}
 		case "subject-line": {
-			return formatSubjectLineConcern(concern, commit)
+			return formatSubjectLineConcern(concern, commit, configuration)
 		}
 	}
 }
@@ -45,10 +51,14 @@ const RANGE_PREFIX = "╭─"
 const MESSAGE_PREFIX = "╰─"
 const MESSAGE_SUFFIX = "─╯"
 
-function formatCommitConcern(concern: CommitConcern, commit: Commit): string {
+function formatCommitConcern(
+	concern: CommitConcern,
+	commit: Commit,
+	configuration: Configuration,
+): string {
 	const formattedSubjectLine = formatTokenisedLine(commit.subjectLine)
 	const commitLine = `${commit.sha.slice(0, SHORT_SHA_LENGTH)} ${formattedSubjectLine}`
-	const message = ruleMessage(concern.rule)
+	const message = ruleMessage(concern.rule, configuration)
 
 	const rangeLine = indentString(
 		RANGE_PREFIX + "─".repeat(formattedSubjectLine.length),
@@ -56,14 +66,18 @@ function formatCommitConcern(concern: CommitConcern, commit: Commit): string {
 	)
 
 	const messageLine = indentString(
-		`${MESSAGE_PREFIX} ${message}\n   (${concern.rule.key})`,
+		`${MESSAGE_PREFIX} ${message}\n   (${concern.rule})`,
 		SHORT_SHA_LENGTH - MESSAGE_PREFIX.length + 1,
 	)
 
 	return `${commitLine}\n${rangeLine}\n${messageLine}`
 }
 
-function formatSubjectLineConcern(concern: SubjectLineConcern, commit: Commit): string {
+function formatSubjectLineConcern(
+	concern: SubjectLineConcern,
+	commit: Commit,
+	configuration: Configuration,
+): string {
 	const commitLine = `${commit.sha.slice(0, SHORT_SHA_LENGTH)} ${formatTokenisedLine(commit.subjectLine)}`
 
 	const [rangeStart, rangeEnd] = concern.range
@@ -73,40 +87,37 @@ function formatSubjectLineConcern(concern: SubjectLineConcern, commit: Commit): 
 	const longHalfLength = Math.trunc(length / 2)
 	const shortHalfLength = length - longHalfLength - 1
 
-	const message = ruleMessage(concern.rule)
+	const message = ruleMessage(concern.rule, configuration)
 	const anchoredRight = message.length + MESSAGE_SUFFIX.length < offset + longHalfLength
 
 	const rangeLine = indentString(formatCharacterRange(concern.range, anchoredRight), offset)
 
 	const messageLine = anchoredRight
 		? indentString(
-				`${message} ${MESSAGE_SUFFIX}\n(${concern.rule.key})`,
+				`${message} ${MESSAGE_SUFFIX}\n(${concern.rule})`,
 				offset + longHalfLength - message.length - MESSAGE_SUFFIX.length,
 			)
-		: indentString(
-				`${MESSAGE_PREFIX} ${message}\n   (${concern.rule.key})`,
-				offset + shortHalfLength,
-			)
+		: indentString(`${MESSAGE_PREFIX} ${message}\n   (${concern.rule})`, offset + shortHalfLength)
 
 	return `${commitLine}\n${rangeLine}\n${messageLine}`
 }
 
-function ruleMessage(rule: RuleContext): string {
-	switch (rule.key) {
+function ruleMessage(rule: RuleKey, configuration: Configuration): string {
+	switch (rule) {
 		case "noBlankSubjectLines": {
 			return "Subject lines must contain at least one non-whitespace character."
 		}
 		case "noExcessiveCommitsPerBranch": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "noMergeCommits": {
 			return "Merge commits are not allowed."
 		}
 		case "noRepeatedSubjectLines": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "noRestrictedFooterLines": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "noRevertRevertCommits": {
 			return "Cherry-pick the original commit instead of reverting it over."
@@ -118,43 +129,54 @@ function ruleMessage(rule: RuleContext): string {
 			return "Combine squash commits with their ancestors."
 		}
 		case "noUnexpectedPunctuation": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "noUnexpectedWhitespace": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useAuthorEmailPatterns": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useAuthorNamePatterns": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useCapitalisedSubjectLines": {
 			return "The first letter in subject lines must be in uppercase."
 		}
 		case "useCommitterEmailPatterns": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useCommitterNamePatterns": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useConciseSubjectLines": {
-			return `Subject lines must not exceed ${rule.options.maxLength} characters.`
+			const options = getRuleOptions(rule, configuration)
+			return `Subject lines must not exceed ${options.maxLength} characters.`
 		}
 		case "useEmptyLineBeforeBodyLines": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useImperativeSubjectLines": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useIssueLinks": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useLineWrapping": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 		case "useSignedCommits": {
-			throw new Error(`Not implemented yet: ${rule.key}`)
+			throw new Error(`Not implemented yet: ${rule}`)
 		}
 	}
+}
+
+function getRuleOptions<Key extends RuleKey>(
+	rule: Key,
+	configuration: Configuration,
+): NonNullable<RuleOptions<Key>> {
+	return requireNotNullish(
+		configuration.rules[rule],
+		() => `Concern raised for disabled rule '${rule}'`,
+	)
 }


### PR DESCRIPTION
The configuration object provides more information to reports than
isolated rule contexts, which were introduced in commit 4fc3213.