### PR TITLE
Declare specific rule keys per concern type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Always use mise to install dependencies and run tasks. Never use pnpm, npm, npx,
 - Write a description of the rule and the motivation behind it in JSDoc
 - For each commit to verify, return the appropriate concern when the rule is violated and return null when all is good
 - If it is a brand-new rule, add it to `Rule.ts` and default configurations with meaningful options and write unit tests
+- Add the rule key to the relevant concern types in `src/domains/rules/concerns/`
 - Write unit tests for the rule logic in isolation, including multiple positive and negative cases, covering edge cases and different configurations if applicable
 - Support the new rule in reports in `src/domains/rules/reports/`
 - Write unit tests for the reports (preserve the alphabetical rule order)

--- a/src/domains/rules/concerns/BodyLineConcern.ts
+++ b/src/domains/rules/concerns/BodyLineConcern.ts
@@ -1,17 +1,23 @@
-import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type BodyLineConcern = {
 	location: "body-line"
-	rule: RuleKey
+	rule: BodyLineConcernRuleKey
 	commitSha: CommitSha
 	line: number
 	range: CharacterRange
 }
 
+export type BodyLineConcernRuleKey =
+	| "noRestrictedTrailers"
+	| "noUnexpectedPunctuation"
+	| "noUnexpectedWhitespace"
+	| "useEmptyLineBeforeBodyLines"
+	| "useLineWrapping"
+
 export function bodyLineConcern(
-	rule: RuleKey,
+	rule: BodyLineConcernRuleKey,
 	commitSha: CommitSha,
 	props: Pick<BodyLineConcern, "line" | "range">,
 ): BodyLineConcern {

--- a/src/domains/rules/concerns/CommitConcern.ts
+++ b/src/domains/rules/concerns/CommitConcern.ts
@@ -1,12 +1,17 @@
-import type { RuleKey } from "#rules/Rule.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type CommitConcern = {
 	location: "commit"
-	rule: RuleKey
+	rule: CommitConcernRuleKey
 	commitSha: CommitSha
 }
 
-export function commitConcern(rule: RuleKey, commitSha: CommitSha): CommitConcern {
+export type CommitConcernRuleKey =
+	| "noExcessiveCommitsPerBranch"
+	| "noMergeCommits"
+	| "noRepeatedSubjectLines"
+	| "useSignedCommits"
+
+export function commitConcern(rule: CommitConcernRuleKey, commitSha: CommitSha): CommitConcern {
 	return { location: "commit", rule, commitSha }
 }

--- a/src/domains/rules/concerns/SubjectLineConcern.ts
+++ b/src/domains/rules/concerns/SubjectLineConcern.ts
@@ -1,16 +1,27 @@
-import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type SubjectLineConcern = {
 	location: "subject-line"
-	rule: RuleKey
+	rule: SubjectLineConcernRuleKey
 	commitSha: CommitSha
 	range: CharacterRange
 }
 
+export type SubjectLineConcernRuleKey =
+	| "noBlankSubjectLines"
+	| "noRevertRevertCommits"
+	| "noSingleWordSubjectLines"
+	| "noSquashMarkers"
+	| "noUnexpectedPunctuation"
+	| "noUnexpectedWhitespace"
+	| "useCapitalisedSubjectLines"
+	| "useConciseSubjectLines"
+	| "useImperativeSubjectLines"
+	| "useIssueLinks"
+
 export function subjectLineConcern(
-	rule: RuleKey,
+	rule: SubjectLineConcernRuleKey,
 	commitSha: CommitSha,
 	props: Pick<SubjectLineConcern, "range">,
 ): SubjectLineConcern {

--- a/src/domains/rules/concerns/UserIdentityConcern.ts
+++ b/src/domains/rules/concerns/UserIdentityConcern.ts
@@ -1,15 +1,20 @@
-import type { RuleKey } from "#rules/Rule.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 export type UserIdentityConcern = {
 	location: "user-identity"
-	rule: RuleKey
+	rule: UserIdentityConcernRuleKey
 	commitSha: CommitSha
 	field: "author:email" | "author:name" | "committer:email" | "committer:name"
 }
 
+export type UserIdentityConcernRuleKey =
+	| "useAuthorEmailPatterns"
+	| "useAuthorNamePatterns"
+	| "useCommitterEmailPatterns"
+	| "useCommitterNamePatterns"
+
 export function userIdentityConcern(
-	rule: RuleKey,
+	rule: UserIdentityConcernRuleKey,
 	commitSha: CommitSha,
 	props: Pick<UserIdentityConcern, "field">,
 ): UserIdentityConcern {

--- a/src/domains/rules/reports/CommitwiseReport.ts
+++ b/src/domains/rules/reports/CommitwiseReport.ts
@@ -52,7 +52,7 @@ function formatCommitConcern(
 	commit: Commit,
 	configuration: Configuration,
 ): string {
-	const message = getRuleMessage(concern.rule, configuration)
+	const message = getRuleMessage(concern, configuration)
 
 	const commitLine = getCommitLine(commit)
 	const rangeLine = indentString(
@@ -69,7 +69,7 @@ function formatSubjectLineConcern(
 	commit: Commit,
 	configuration: Configuration,
 ): string {
-	const message = getRuleMessage(concern.rule, configuration)
+	const message = getRuleMessage(concern, configuration)
 
 	const [rangeStart, rangeEnd] = concern.range
 	const length = rangeEnd - rangeStart
@@ -95,7 +95,7 @@ function formatBodyLineConcern(
 	commit: Commit,
 	configuration: Configuration,
 ): string {
-	const message = getRuleMessage(concern.rule, configuration)
+	const message = getRuleMessage(concern, configuration)
 
 	const [rangeStart, rangeEnd] = concern.range
 	const length = rangeEnd - rangeStart
@@ -153,7 +153,7 @@ function formatUserIdentityConcern(
 	commit: Commit,
 	configuration: Configuration,
 ): string {
-	const message = getRuleMessage(concern.rule, configuration)
+	const message = getRuleMessage(concern, configuration)
 
 	const identityLine = `╰─ ${getIdentityLine(concern, commit)}`
 
@@ -202,7 +202,9 @@ type RuleMessage = {
 	sidenote: string
 }
 
-function getRuleMessage(rule: RuleKey, configuration: Configuration): RuleMessage {
+function getRuleMessage(concern: Concern, configuration: Configuration): RuleMessage {
+	const rule = concern.rule
+
 	function ruleMessage(violation: string, sidenote = ""): RuleMessage {
 		return { rule, violation, sidenote }
 	}


### PR DESCRIPTION
This enriches the rule messages in commitwise reports with information about the concern such as character ranges.