### PR TITLE
Use concern mapping and rule config in unit tests

### DIFF
--- a/src/domains/commits/Commit.fixtures.ts
+++ b/src/domains/commits/Commit.fixtures.ts
@@ -1,9 +1,10 @@
 import { type Commit, mapCrudeCommitToCommit } from "#commits/Commit.ts"
 import { type CrudeCommitTemplate, fakeCrudeCommit } from "#commits/CrudeCommit.fixtures.ts"
-import type { Configuration } from "#configurations/Configuration.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
+import type { TokenConfiguration } from "#configurations/Configuration.ts"
 
 export function fakeCommitFactory(
-	configuration: Configuration,
+	configuration: TokenConfiguration = fakeTokenConfiguration(),
 ): (overrides?: CrudeCommitTemplate) => Commit {
 	return (overrides?: CrudeCommitTemplate): Commit =>
 		mapCrudeCommitToCommit(fakeCrudeCommit(overrides), configuration)

--- a/src/domains/commits/Commit.tests.ts
+++ b/src/domains/commits/Commit.tests.ts
@@ -3,11 +3,11 @@ import { mapCrudeCommitToCommit } from "#commits/Commit.ts"
 import { fakeCrudeCommit } from "#commits/CrudeCommit.fixtures.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine, TokenisedLines } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	sha

--- a/src/domains/commits/Commit.ts
+++ b/src/domains/commits/Commit.ts
@@ -7,7 +7,7 @@ import { tokeniseSquashMarkers } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { Token, TokenisedLine, TokenisedLines } from "#commits/tokens/Token.ts"
 import { tokeniseTrailers } from "#commits/tokens/TrailerToken.ts"
-import type { Configuration, TokenConfiguration } from "#configurations/Configuration.ts"
+import type { TokenConfiguration } from "#configurations/Configuration.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 
 /**
@@ -29,7 +29,7 @@ export type Commits = Array<Commit>
 
 export function mapCrudeCommitToCommit(
 	crudeCommit: CrudeCommit,
-	configuration: Configuration,
+	configuration: TokenConfiguration,
 ): Commit {
 	const [crudeSubjectLine = "", ...crudeBodyLines] = crudeCommit.message.split("\n")
 
@@ -41,8 +41,8 @@ export function mapCrudeCommitToCommit(
 		authorEmail: crudeCommit.authorEmail,
 		committerName: crudeCommit.committerName,
 		committerEmail: crudeCommit.committerEmail,
-		subjectLine: tokeniseSubjectLine(crudeSubjectLine, configuration.tokens),
-		bodyLines: tokeniseBodyLines(crudeBodyLines, configuration.tokens),
+		subjectLine: tokeniseSubjectLine(crudeSubjectLine, configuration),
+		bodyLines: tokeniseBodyLines(crudeBodyLines, configuration),
 	}
 }
 

--- a/src/domains/commits/tokens/DependencyVersionToken.tests.ts
+++ b/src/domains/commits/tokens/DependencyVersionToken.tests.ts
@@ -7,9 +7,9 @@ import { revertMarker } from "#commits/tokens/RevertMarkerToken.ts"
 import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	subjectLine                                                      | expectedTokens

--- a/src/domains/commits/tokens/InlineCodeToken.tests.ts
+++ b/src/domains/commits/tokens/InlineCodeToken.tests.ts
@@ -8,9 +8,9 @@ import { revertMarker } from "#commits/tokens/RevertMarkerToken.ts"
 import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	subjectLine                                         | expectedTokens

--- a/src/domains/commits/tokens/IssueLinkToken.tests.ts
+++ b/src/domains/commits/tokens/IssueLinkToken.tests.ts
@@ -6,16 +6,16 @@ import { revertMarker } from "#commits/tokens/RevertMarkerToken.ts"
 import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { issueLinkConfiguration } from "#configurations/IssueLinkTokenConfiguration.ts"
 
-const githubStyle = fakeConfiguration({
-	tokens: { issueLinks: issueLinkConfiguration(["#", "GH-", "GL-"], ["(no-issue)", "[incident]"]) },
+const githubStyle = fakeTokenConfiguration({
+	issueLinks: issueLinkConfiguration(["#", "GH-", "GL-"], ["(no-issue)", "[incident]"]),
 })
-const jiraStyle = fakeConfiguration({
-	tokens: { issueLinks: issueLinkConfiguration(["UNICORN-"], ["#SECURITY"]) },
+const jiraStyle = fakeTokenConfiguration({
+	issueLinks: issueLinkConfiguration(["UNICORN-"], ["#SECURITY"]),
 })
-const none = fakeConfiguration({ tokens: { issueLinks: null } })
+const none = fakeTokenConfiguration({ issueLinks: null })
 
 describe.each`
 	subjectLine                                                        | expectedTokens

--- a/src/domains/commits/tokens/RevertMarkerToken.tests.ts
+++ b/src/domains/commits/tokens/RevertMarkerToken.tests.ts
@@ -7,9 +7,9 @@ import { revertMarker } from "#commits/tokens/RevertMarkerToken.ts"
 import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	subjectLine                                                                        | expectedTokens

--- a/src/domains/commits/tokens/SquashMarkerToken.tests.ts
+++ b/src/domains/commits/tokens/SquashMarkerToken.tests.ts
@@ -7,9 +7,9 @@ import { revertMarker } from "#commits/tokens/RevertMarkerToken.ts"
 import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine } from "#commits/tokens/Token.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	subjectLine                                                                        | expectedTokens

--- a/src/domains/commits/tokens/TrailerToken.tests.ts
+++ b/src/domains/commits/tokens/TrailerToken.tests.ts
@@ -9,9 +9,9 @@ import { squashMarker } from "#commits/tokens/SquashMarkerToken.ts"
 import { text } from "#commits/tokens/TextToken.ts"
 import type { TokenisedLine, TokenisedLines } from "#commits/tokens/Token.ts"
 import { trailer } from "#commits/tokens/TrailerToken.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 
-const configuration = fakeConfiguration()
+const configuration = fakeTokenConfiguration()
 
 describe.each`
 	subjectLine                                         | body                                                                                                                                                                                                                                        | expectedSubjectLine                                                                                                                                       | expectedBodyLines

--- a/src/domains/configurations/Configuration.fixtures.ts
+++ b/src/domains/configurations/Configuration.fixtures.ts
@@ -60,6 +60,35 @@ export function fakeConfiguration(overrides: ConfigurationTemplate = {}): Config
 	}
 }
 
+export function emptyRuleConfiguration(
+	overrides: Partial<RuleConfiguration> = {},
+): RuleConfiguration {
+	return {
+		noBlankSubjectLines: null,
+		noExcessiveCommitsPerBranch: null,
+		noMergeCommits: null,
+		noRepeatedSubjectLines: null,
+		noRestrictedTrailers: null,
+		noRevertRevertCommits: null,
+		noSingleWordSubjectLines: null,
+		noSquashMarkers: null,
+		noUnexpectedPunctuation: null,
+		noUnexpectedWhitespace: null,
+		useAuthorEmailPatterns: null,
+		useAuthorNamePatterns: null,
+		useCapitalisedSubjectLines: null,
+		useCommitterEmailPatterns: null,
+		useCommitterNamePatterns: null,
+		useConciseSubjectLines: null,
+		useEmptyLineBeforeBodyLines: null,
+		useImperativeSubjectLines: null,
+		useIssueLinks: null,
+		useLineWrapping: null,
+		useSignedCommits: null,
+		...overrides,
+	}
+}
+
 export function fakeTokenConfiguration(
 	overrides: Partial<TokenConfiguration> = {},
 ): TokenConfiguration {

--- a/src/domains/configurations/Configuration.fixtures.ts
+++ b/src/domains/configurations/Configuration.fixtures.ts
@@ -3,19 +3,15 @@ import type {
 	RuleConfiguration,
 	TokenConfiguration,
 } from "#configurations/Configuration.ts"
-import { getDefaultTokenConfiguration } from "#configurations/GetDefaultConfiguration.ts"
+import { issueLinkConfiguration } from "#configurations/IssueLinkTokenConfiguration.ts"
 
 export type ConfigurationTemplate = {
-	tokens?: Partial<TokenConfiguration>
 	rules?: Partial<RuleConfiguration>
+	tokens?: Partial<TokenConfiguration>
 }
 
 export function fakeConfiguration(overrides: ConfigurationTemplate = {}): Configuration {
 	return {
-		tokens: {
-			...getDefaultTokenConfiguration(),
-			...overrides.tokens,
-		},
 		rules: {
 			noBlankSubjectLines: {},
 			noExcessiveCommitsPerBranch: { maxCommits: 10 },
@@ -60,5 +56,15 @@ export function fakeConfiguration(overrides: ConfigurationTemplate = {}): Config
 			useSignedCommits: {},
 			...overrides.rules,
 		},
+		tokens: fakeTokenConfiguration(overrides.tokens),
+	}
+}
+
+export function fakeTokenConfiguration(
+	overrides: Partial<TokenConfiguration> = {},
+): TokenConfiguration {
+	return {
+		issueLinks: issueLinkConfiguration(["#", "GH-", "GL-"]),
+		...overrides,
 	}
 }

--- a/src/domains/configurations/Configuration.ts
+++ b/src/domains/configurations/Configuration.ts
@@ -2,8 +2,8 @@ import type { IssueLinkTokenConfiguration } from "#configurations/IssueLinkToken
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
 
 export type Configuration = {
-	tokens: TokenConfiguration
 	rules: RuleConfiguration
+	tokens: TokenConfiguration
 }
 
 /**

--- a/src/domains/programs/Program.ts
+++ b/src/domains/programs/Program.ts
@@ -11,10 +11,10 @@ export async function program(_args: Array<string>): Promise<ExitCode> {
 		const [crudeCommits, configuration] = await Promise.all([getCrudeCommits(), getConfiguration()])
 
 		const commits = crudeCommits.map((crudeCommit) =>
-			mapCrudeCommitToCommit(crudeCommit, configuration),
+			mapCrudeCommitToCommit(crudeCommit, configuration.tokens),
 		)
 
-		const concerns = mapCommitsToConcerns(commits, configuration)
+		const concerns = mapCommitsToConcerns(commits, configuration.rules)
 
 		printMessage(JSON.stringify(concerns))
 		printMessage("Not implemented yet")

--- a/src/domains/rules/NoBlankSubjectLines.tests.ts
+++ b/src/domains/rules/NoBlankSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noBlankSubjectLines } from "#rules/NoBlankSubjectLines.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noBlankSubjectLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine | expectedRange

--- a/src/domains/rules/NoBlankSubjectLines.tests.ts
+++ b/src/domains/rules/NoBlankSubjectLines.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { noBlankSubjectLines } from "#rules/NoBlankSubjectLines.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noBlankSubjectLines" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -25,7 +27,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first character in the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -35,7 +37,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -64,7 +66,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first character after the insignificant tokens", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -74,7 +76,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noBlankSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -102,7 +104,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.subjectLine })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines([commit], enabled)
+		const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -110,7 +112,7 @@ describe.each`
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noBlankSubjectLines([commit], null)
+		const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -129,7 +131,7 @@ describe("when verifying a set of multiple commits and some commits have blank s
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with blank subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -141,7 +143,7 @@ describe("when verifying a set of multiple commits and some commits have blank s
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -158,7 +160,7 @@ describe("when verifying a set of multiple commits and no commits have blank sub
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -166,7 +168,7 @@ describe("when verifying a set of multiple commits and no commits have blank sub
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noBlankSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoExcessiveCommitsPerBranch.tests.ts
+++ b/src/domains/rules/NoExcessiveCommitsPerBranch.tests.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import { noExcessiveCommitsPerBranch } from "#rules/NoExcessiveCommitsPerBranch.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noExcessiveCommitsPerBranch" satisfies RuleKey
-const enabled3: RuleOptions<typeof rule> = { maxCommits: 3 }
-const enabled10: RuleOptions<typeof rule> = { maxCommits: 10 }
+
+const disabled = emptyRuleConfiguration()
+const enabled3 = emptyRuleConfiguration({ [rule]: { maxCommits: 3 } })
+const enabled10 = emptyRuleConfiguration({ [rule]: { maxCommits: 10 } })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -25,7 +27,7 @@ describe("when verifying a set of 6 commits when up to 3 commits are allowed", (
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled3)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled3)
 
 		it("raises concerns about commits 4-6", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -37,7 +39,7 @@ describe("when verifying a set of 6 commits when up to 3 commits are allowed", (
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -53,7 +55,7 @@ describe("when verifying a set of 3 commits when up to 3 commits are allowed", (
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled3)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled3)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -61,7 +63,7 @@ describe("when verifying a set of 3 commits when up to 3 commits are allowed", (
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -73,7 +75,7 @@ describe("when verifying a set of 1 commit when up to 3 commits are allowed", ()
 	const commits: Vector<Commit, 1> = [fakeCommit({ message: "label the mystery switch" })]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled3)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled3)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -81,7 +83,7 @@ describe("when verifying a set of 1 commit when up to 3 commits are allowed", ()
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -106,7 +108,7 @@ describe("when verifying a set of 12 commits when up to 10 commits are allowed",
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled10)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled10)
 
 		it("raises concerns about commits 11-12", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -117,7 +119,7 @@ describe("when verifying a set of 12 commits when up to 10 commits are allowed",
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -140,7 +142,7 @@ describe("when verifying a set of 10 commits when up to 10 commits are allowed",
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled10)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled10)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -148,7 +150,7 @@ describe("when verifying a set of 10 commits when up to 10 commits are allowed",
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -165,7 +167,7 @@ describe("when verifying a set of 4 commits when up to 10 commits are allowed", 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled10)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled10)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -173,7 +175,7 @@ describe("when verifying a set of 4 commits when up to 10 commits are allowed", 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -198,7 +200,7 @@ describe("when verifying a set of 6 commits when up to 3 commits are allowed and
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled3)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled3)
 
 		it("ignores merge commits when determining excessive commits", () => {
 			expect(actualConcerns).toEqual<Concerns>([commitConcern(rule, commits[5].sha)])
@@ -206,7 +208,7 @@ describe("when verifying a set of 6 commits when up to 3 commits are allowed and
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -227,7 +229,7 @@ describe("when verifying a set of 8 commits when up to 3 commits are allowed and
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, enabled3)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled3)
 
 		it("ignores commits with squash markers when determining excessive commits", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -239,7 +241,7 @@ describe("when verifying a set of 8 commits when up to 3 commits are allowed and
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noExcessiveCommitsPerBranch(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoExcessiveCommitsPerBranch.tests.ts
+++ b/src/domains/rules/NoExcessiveCommitsPerBranch.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { noExcessiveCommitsPerBranch } from "#rules/NoExcessiveCommitsPerBranch.ts"
@@ -13,7 +12,7 @@ const rule = "noExcessiveCommitsPerBranch" satisfies RuleKey
 const enabled3: RuleOptions<typeof rule> = { maxCommits: 3 }
 const enabled10: RuleOptions<typeof rule> = { maxCommits: 10 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe("when verifying a set of 6 commits when up to 3 commits are allowed", () => {
 	const commits: Vector<Commit, 6> = [

--- a/src/domains/rules/NoMergeCommits.tests.ts
+++ b/src/domains/rules/NoMergeCommits.tests.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import { noMergeCommits } from "#rules/NoMergeCommits.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noMergeCommits" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -26,7 +28,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noMergeCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the entire commit", () => {
 				expect(actualConcerns).toEqual<Concerns>([commitConcern(rule, commit.sha)])
@@ -34,7 +36,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noMergeCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -55,7 +57,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noMergeCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -63,7 +65,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noMergeCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -83,7 +85,7 @@ describe("when verifying a set of multiple commits and some commits are merge co
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noMergeCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the merge commits", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -95,7 +97,7 @@ describe("when verifying a set of multiple commits and some commits are merge co
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noMergeCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -112,7 +114,7 @@ describe("when verifying a set of multiple commits and no commits are merge comm
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noMergeCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -120,7 +122,7 @@ describe("when verifying a set of multiple commits and no commits are merge comm
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noMergeCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoMergeCommits.tests.ts
+++ b/src/domains/rules/NoMergeCommits.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { noMergeCommits } from "#rules/NoMergeCommits.ts"
@@ -13,7 +12,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noMergeCommits" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	parents                                                | subjectLine

--- a/src/domains/rules/NoRepeatedSubjectLines.tests.ts
+++ b/src/domains/rules/NoRepeatedSubjectLines.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import { noRepeatedSubjectLines } from "#rules/NoRepeatedSubjectLines.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noRepeatedSubjectLines" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -28,7 +30,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -41,7 +43,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -66,7 +68,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines being whitespace- and case-insensitive", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -81,7 +83,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -115,7 +117,7 @@ describe("when verifying a set of multiple commits and merge commits have repeat
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines, but ignores merge commits", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -127,7 +129,7 @@ describe("when verifying a set of multiple commits and merge commits have repeat
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -148,7 +150,7 @@ describe("when verifying a set of multiple commits and revert commits have repea
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines, but ignores commits with revert markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -160,7 +162,7 @@ describe("when verifying a set of multiple commits and revert commits have repea
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -185,7 +187,7 @@ describe("when verifying a set of multiple commits and squash commits have repea
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines, but ignores commits with squash markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -197,7 +199,7 @@ describe("when verifying a set of multiple commits and squash commits have repea
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -214,7 +216,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with repeated subject lines, but ignores commits with different issue links", () => {
 			expect(actualConcerns).toEqual<Concerns>([commitConcern(rule, commits[2].sha)])
@@ -222,7 +224,7 @@ describe("when verifying a set of multiple commits and some commits have repeate
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -245,7 +247,7 @@ describe("when verifying a set of multiple commits and no commits have repeated 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -253,7 +255,7 @@ describe("when verifying a set of multiple commits and no commits have repeated 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRepeatedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoRepeatedSubjectLines.tests.ts
+++ b/src/domains/rules/NoRepeatedSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { noRepeatedSubjectLines } from "#rules/NoRepeatedSubjectLines.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noRepeatedSubjectLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe("when verifying a set of multiple commits and some commits have repeated subject lines", () => {
 	const commits: Vector<Commit, 10> = [

--- a/src/domains/rules/NoRestrictedTrailers.tests.ts
+++ b/src/domains/rules/NoRestrictedTrailers.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { bodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { noRestrictedTrailers } from "#rules/NoRestrictedTrailers.ts"
@@ -18,7 +17,7 @@ const enabled3: RuleOptions<typeof rule> = {
 	restrictedKeys: ["co-authored-by", "refs", "reviewed-by"],
 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	message                                                                                                                                                                                                                                                        | expectedRanges1                                                                            | expectedRanges2                                               | expectedRanges3

--- a/src/domains/rules/NoRestrictedTrailers.tests.ts
+++ b/src/domains/rules/NoRestrictedTrailers.tests.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import type { RuleConfiguration } from "#configurations/Configuration.ts"
 import { bodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import { noRestrictedTrailers } from "#rules/NoRestrictedTrailers.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noRestrictedTrailers" satisfies RuleKey
 
-const enabledNone: RuleOptions<typeof rule> = { restrictedKeys: [] }
-const enabled1: RuleOptions<typeof rule> = { restrictedKeys: ["signed-off-by"] }
-const enabled2: RuleOptions<typeof rule> = { restrictedKeys: ["co-authored-by", "breaking change"] }
-const enabled3: RuleOptions<typeof rule> = {
-	restrictedKeys: ["co-authored-by", "refs", "reviewed-by"],
-}
+const disabled = emptyRuleConfiguration()
+const enabledNone = emptyRuleConfiguration({
+	[rule]: { restrictedKeys: [] },
+})
+const enabled1 = emptyRuleConfiguration({
+	[rule]: { restrictedKeys: ["signed-off-by"] },
+})
+const enabled2 = emptyRuleConfiguration({
+	[rule]: { restrictedKeys: ["co-authored-by", "breaking change"] },
+})
+const enabled3 = emptyRuleConfiguration({
+	[rule]: { restrictedKeys: ["co-authored-by", "refs", "reviewed-by"] },
+})
 
 const fakeCommit = fakeCommitFactory()
 
@@ -51,25 +59,25 @@ describe.each`
 		const commit = fakeCommit({ message: props.message })
 
 		describe.each`
-			options     | expectedRanges
+			rules       | expectedRanges
 			${enabled1} | ${props.expectedRanges1}
 			${enabled2} | ${props.expectedRanges2}
 			${enabled3} | ${props.expectedRanges3}
 		`(
-			"and the rule is enabled with restrictions on $options.restrictedKeys",
-			(optionProps: {
-				options: RuleOptions<typeof rule>
+			"and the rule is enabled with restrictions on $rules.noRestrictedTrailers.restrictedKeys",
+			(configProps: {
+				rules: RuleConfiguration
 				expectedRanges: Array<{ line: number; range: CharacterRange }>
 			}) => {
-				const actualConcerns = noRestrictedTrailers([commit], optionProps.options)
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it(
 					// oxlint-disable-next-line jest/no-conditional-in-test -- The conditional expression only affects the test name.
-					optionProps.expectedRanges.length > 0
+					configProps.expectedRanges.length > 0
 						? "raises concerns about the disallowed trailer keys"
 						: "does not raise any concerns",
 					() => {
-						const expectedConcerns: Concerns = optionProps.expectedRanges.map((range) =>
+						const expectedConcerns: Concerns = configProps.expectedRanges.map((range) =>
 							bodyLineConcern(rule, commit.sha, range),
 						)
 						expect(actualConcerns).toEqual<Concerns>(expectedConcerns)
@@ -79,7 +87,7 @@ describe.each`
 		)
 
 		describe("and the rule is enabled with no restricted trailers", () => {
-			const actualConcerns = noRestrictedTrailers([commit], enabledNone)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledNone)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -87,7 +95,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noRestrictedTrailers([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -112,14 +120,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.message })
 
 		describe.each`
-			options
+			rules
 			${enabled1}
 			${enabled2}
 			${enabled3}
 		`(
-			"and the rule is enabled with restrictions on $options.restrictedKeys",
-			(optionProps: { options: RuleOptions<typeof rule> }) => {
-				const actualConcerns = noRestrictedTrailers([commit], optionProps.options)
+			"and the rule is enabled with restrictions on $rules.noRestrictedTrailers.restrictedKeys",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -128,7 +136,7 @@ describe.each`
 		)
 
 		describe("and the rule is enabled with no restricted trailers", () => {
-			const actualConcerns = noRestrictedTrailers([commit], enabledNone)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledNone)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -136,7 +144,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noRestrictedTrailers([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -168,29 +176,29 @@ describe("when verifying a set of multiple commits and some commits contain rest
 	]
 
 	describe.each`
-		options     | expectedConcerns
+		rules       | expectedConcerns
 		${enabled1} | ${[]}
 		${enabled2} | ${[bodyLineConcern(rule, commits[1].sha, { line: 1, range: [0, 15] }), bodyLineConcern(rule, commits[5].sha, { line: 1, range: [0, 16] })]}
 		${enabled3} | ${[bodyLineConcern(rule, commits[1].sha, { line: 1, range: [0, 15] }), bodyLineConcern(rule, commits[1].sha, { line: 2, range: [1, 13] }), bodyLineConcern(rule, commits[2].sha, { line: 1, range: [0, 12] })]}
 	`(
-		"and the rule is enabled with $options.restrictedKeys restricted",
-		(props: { options: RuleOptions<typeof rule>; expectedConcerns: Concerns }) => {
-			const actualConcerns = noRestrictedTrailers(commits, props.options)
+		"and the rule is enabled with restrictions on $rules.noRestrictedTrailers.restrictedKeys",
+		(configProps: { rules: RuleConfiguration; expectedConcerns: Concerns }) => {
+			const actualConcerns = mapCommitsToConcerns(commits, configProps.rules)
 
 			it(
 				// oxlint-disable-next-line jest/no-conditional-in-test -- The conditional expression only affects the test name.
-				props.expectedConcerns.length > 0
+				configProps.expectedConcerns.length > 0
 					? "raises concerns about the disallowed trailer keys"
 					: "does not raise any concerns",
 				() => {
-					expect(actualConcerns).toEqual(props.expectedConcerns)
+					expect(actualConcerns).toEqual(configProps.expectedConcerns)
 				},
 			)
 		},
 	)
 
 	describe("and the rule is enabled with no restricted trailers", () => {
-		const actualConcerns = noRestrictedTrailers(commits, enabledNone)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledNone)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -198,7 +206,7 @@ describe("when verifying a set of multiple commits and some commits contain rest
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRestrictedTrailers(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -231,14 +239,14 @@ describe("when verifying a set of multiple commits and no commits contain restri
 	]
 
 	describe.each`
-		options
+		rules
 		${enabled1}
 		${enabled2}
 		${enabled3}
 	`(
-		"and the rule is enabled with restrictions on $options.restrictedKeys",
-		(optionProps: { options: RuleOptions<typeof rule> }) => {
-			const actualConcerns = noRestrictedTrailers(commits, optionProps.options)
+		"and the rule is enabled with restrictions on $rules.noRestrictedTrailers.restrictedKeys",
+		(configProps: { rules: RuleConfiguration }) => {
+			const actualConcerns = mapCommitsToConcerns(commits, configProps.rules)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -247,7 +255,7 @@ describe("when verifying a set of multiple commits and no commits contain restri
 	)
 
 	describe("and the rule is enabled with no restricted trailers", () => {
-		const actualConcerns = noRestrictedTrailers(commits, enabledNone)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledNone)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -255,7 +263,7 @@ describe("when verifying a set of multiple commits and no commits contain restri
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRestrictedTrailers(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoRevertRevertCommits.tests.ts
+++ b/src/domains/rules/NoRevertRevertCommits.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { noRevertRevertCommits } from "#rules/NoRevertRevertCommits.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noRevertRevertCommits" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -29,7 +31,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the revert marker", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -39,7 +41,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -63,7 +65,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -71,7 +73,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -105,7 +107,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -113,7 +115,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noRevertRevertCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -136,7 +138,7 @@ describe("when verifying a set of multiple commits and some commits have revert 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with double revert markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -149,7 +151,7 @@ describe("when verifying a set of multiple commits and some commits have revert 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -168,7 +170,7 @@ describe("when verifying a set of multiple commits and no commits have revert ma
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -176,7 +178,7 @@ describe("when verifying a set of multiple commits and no commits have revert ma
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noRevertRevertCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoRevertRevertCommits.tests.ts
+++ b/src/domains/rules/NoRevertRevertCommits.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noRevertRevertCommits } from "#rules/NoRevertRevertCommits.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noRevertRevertCommits" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                                                                   | expectedRange

--- a/src/domains/rules/NoSingleWordSubjectLines.tests.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { noSingleWordSubjectLines } from "#rules/NoSingleWordSubjectLines.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noSingleWordSubjectLines" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -45,7 +47,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the single word", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -55,7 +57,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -80,7 +82,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -88,7 +90,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -110,7 +112,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -118,7 +120,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -147,7 +149,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -155,7 +157,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSingleWordSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -177,7 +179,7 @@ describe("when verifying a set of multiple commits and some commits have single-
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with single-word subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -190,7 +192,7 @@ describe("when verifying a set of multiple commits and some commits have single-
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -207,7 +209,7 @@ describe("when verifying a set of multiple commits and no commits have single-wo
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -215,7 +217,7 @@ describe("when verifying a set of multiple commits and no commits have single-wo
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noSingleWordSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoSingleWordSubjectLines.tests.ts
+++ b/src/domains/rules/NoSingleWordSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noSingleWordSubjectLines } from "#rules/NoSingleWordSubjectLines.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noSingleWordSubjectLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                         | expectedRange

--- a/src/domains/rules/NoSquashMarkers.tests.ts
+++ b/src/domains/rules/NoSquashMarkers.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import { noSquashMarkers } from "#rules/NoSquashMarkers.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "noSquashMarkers" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -33,7 +35,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the squash marker", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -43,7 +45,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSquashMarkers([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -63,7 +65,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about all squash markers", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -73,7 +75,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSquashMarkers([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -113,7 +115,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = noSquashMarkers([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -121,7 +123,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = noSquashMarkers([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -142,7 +144,7 @@ describe("when verifying a set of multiple commits and some commits have squash 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSquashMarkers(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with squash markers", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -154,7 +156,7 @@ describe("when verifying a set of multiple commits and some commits have squash 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noSquashMarkers(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -172,7 +174,7 @@ describe("when verifying a set of multiple commits and no commits have squash ma
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = noSquashMarkers(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -180,7 +182,7 @@ describe("when verifying a set of multiple commits and no commits have squash ma
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = noSquashMarkers(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/NoSquashMarkers.tests.ts
+++ b/src/domains/rules/NoSquashMarkers.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import { noSquashMarkers } from "#rules/NoSquashMarkers.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "noSquashMarkers" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                             | expectedRange

--- a/src/domains/rules/UseAuthorEmailPatterns.tests.ts
+++ b/src/domains/rules/UseAuthorEmailPatterns.tests.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useAuthorEmailPatterns } from "#rules/UseAuthorEmailPatterns.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useAuthorEmailPatterns" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {
-	patterns: [String.raw`\d+\+.+@users\.noreply\.github\.com`, String.raw`.+@fictivecompany\.com`],
-}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({
+	[rule]: {
+		patterns: [String.raw`\d+\+.+@users\.noreply\.github\.com`, String.raw`.+@fictivecompany\.com`],
+	},
+})
 
 const fakeCommit = fakeCommitFactory()
 
@@ -31,7 +35,7 @@ describe.each`
 		const commit = fakeCommit({ authorEmail: props.authorEmail })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useAuthorEmailPatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the author's email address", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -41,7 +45,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useAuthorEmailPatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -63,7 +67,7 @@ describe.each`
 		const commit = fakeCommit({ authorEmail: props.authorEmail })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useAuthorEmailPatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -71,7 +75,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useAuthorEmailPatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -92,7 +96,7 @@ describe("when verifying a set of multiple commits and some commits have author 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useAuthorEmailPatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with invalid author email addresses", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -105,7 +109,7 @@ describe("when verifying a set of multiple commits and some commits have author 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useAuthorEmailPatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -123,7 +127,7 @@ describe("when verifying a set of multiple commits and all commits have author e
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useAuthorEmailPatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -131,7 +135,7 @@ describe("when verifying a set of multiple commits and all commits have author e
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useAuthorEmailPatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseAuthorEmailPatterns.tests.ts
+++ b/src/domains/rules/UseAuthorEmailPatterns.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -13,7 +12,7 @@ const enabled: RuleOptions<typeof rule> = {
 	patterns: [String.raw`\d+\+.+@users\.noreply\.github\.com`, String.raw`.+@fictivecompany\.com`],
 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	authorEmail

--- a/src/domains/rules/UseAuthorNamePatterns.tests.ts
+++ b/src/domains/rules/UseAuthorNamePatterns.tests.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useAuthorNamePatterns } from "#rules/UseAuthorNamePatterns.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useAuthorNamePatterns" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {
-	patterns: [String.raw`\p{Lu}.*\s.+`, String.raw`dependabot\[bot\]`, String.raw`renovate\[bot\]`],
-}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({
+	[rule]: {
+		patterns: [
+			String.raw`\p{Lu}.*\s.+`,
+			String.raw`dependabot\[bot\]`,
+			String.raw`renovate\[bot\]`,
+		],
+	},
+})
 
 const fakeCommit = fakeCommitFactory()
 
@@ -31,7 +39,7 @@ describe.each`
 		const commit = fakeCommit({ authorName: props.authorName })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useAuthorNamePatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the author's name", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -41,7 +49,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useAuthorNamePatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -64,7 +72,7 @@ describe.each`
 		const commit = fakeCommit({ authorName: props.authorName })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useAuthorNamePatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -72,7 +80,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useAuthorNamePatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -93,7 +101,7 @@ describe("when verifying a set of multiple commits and some commits have author 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useAuthorNamePatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with invalid author names", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -105,7 +113,7 @@ describe("when verifying a set of multiple commits and some commits have author 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useAuthorNamePatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -123,7 +131,7 @@ describe("when verifying a set of multiple commits and all commits have author n
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useAuthorNamePatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -131,7 +139,7 @@ describe("when verifying a set of multiple commits and all commits have author n
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useAuthorNamePatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseAuthorNamePatterns.tests.ts
+++ b/src/domains/rules/UseAuthorNamePatterns.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -13,7 +12,7 @@ const enabled: RuleOptions<typeof rule> = {
 	patterns: [String.raw`\p{Lu}.*\s.+`, String.raw`dependabot\[bot\]`, String.raw`renovate\[bot\]`],
 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	authorName

--- a/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useCapitalisedSubjectLines } from "#rules/UseCapitalisedSubjectLines.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useCapitalisedSubjectLines" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -37,7 +39,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first non-capitalised character", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -47,7 +49,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -80,7 +82,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -88,7 +90,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -111,7 +113,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -119,7 +121,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCapitalisedSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -139,7 +141,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.subjectLine })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines([commit], enabled)
+		const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -147,7 +149,7 @@ describe.each`
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines([commit], null)
+		const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -169,7 +171,7 @@ describe("when verifying a set of multiple commits and some commits have non-cap
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with non-capitalised subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -181,7 +183,7 @@ describe("when verifying a set of multiple commits and some commits have non-cap
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -198,7 +200,7 @@ describe("when verifying a set of multiple commits and all commits have capitali
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -206,7 +208,7 @@ describe("when verifying a set of multiple commits and all commits have capitali
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCapitalisedSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
+++ b/src/domains/rules/UseCapitalisedSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "useCapitalisedSubjectLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                                      | expectedRange

--- a/src/domains/rules/UseCommitterEmailPatterns.tests.ts
+++ b/src/domains/rules/UseCommitterEmailPatterns.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -17,7 +16,7 @@ const enabled: RuleOptions<typeof rule> = {
 	],
 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	committerEmail

--- a/src/domains/rules/UseCommitterEmailPatterns.tests.ts
+++ b/src/domains/rules/UseCommitterEmailPatterns.tests.ts
@@ -1,20 +1,24 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useCommitterEmailPatterns } from "#rules/UseCommitterEmailPatterns.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useCommitterEmailPatterns" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {
-	patterns: [
-		String.raw`\d+\+.+@users\.noreply\.github\.com`,
-		String.raw`noreply@github\.com`,
-		String.raw`.+@fastforward\.com`,
-	],
-}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({
+	[rule]: {
+		patterns: [
+			String.raw`\d+\+.+@users\.noreply\.github\.com`,
+			String.raw`noreply@github\.com`,
+			String.raw`.+@fastforward\.com`,
+		],
+	},
+})
 
 const fakeCommit = fakeCommitFactory()
 
@@ -35,7 +39,7 @@ describe.each`
 		const commit = fakeCommit({ committerEmail: props.committerEmail })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCommitterEmailPatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the committer's email address", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -45,7 +49,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCommitterEmailPatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -68,7 +72,7 @@ describe.each`
 		const commit = fakeCommit({ committerEmail: props.committerEmail })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCommitterEmailPatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -76,7 +80,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCommitterEmailPatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -97,7 +101,7 @@ describe("when verifying a set of multiple commits and some commits have committ
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCommitterEmailPatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with invalid committer email addresses", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -111,7 +115,7 @@ describe("when verifying a set of multiple commits and some commits have committ
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCommitterEmailPatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -130,7 +134,7 @@ describe("when verifying a set of multiple commits and all commits have committe
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCommitterEmailPatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -138,7 +142,7 @@ describe("when verifying a set of multiple commits and all commits have committe
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCommitterEmailPatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseCommitterNamePatterns.tests.ts
+++ b/src/domains/rules/UseCommitterNamePatterns.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -18,7 +17,7 @@ const enabled: RuleOptions<typeof rule> = {
 	],
 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	committerName

--- a/src/domains/rules/UseCommitterNamePatterns.tests.ts
+++ b/src/domains/rules/UseCommitterNamePatterns.tests.ts
@@ -1,21 +1,25 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { userIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useCommitterNamePatterns } from "#rules/UseCommitterNamePatterns.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useCommitterNamePatterns" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {
-	patterns: [
-		String.raw`\p{Lu}.*\s.+`,
-		String.raw`dependabot\[bot\]`,
-		String.raw`renovate\[bot\]`,
-		String.raw`GitHub`,
-	],
-}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({
+	[rule]: {
+		patterns: [
+			String.raw`\p{Lu}.*\s.+`,
+			String.raw`dependabot\[bot\]`,
+			String.raw`renovate\[bot\]`,
+			String.raw`GitHub`,
+		],
+	},
+})
 
 const fakeCommit = fakeCommitFactory()
 
@@ -37,7 +41,7 @@ describe.each`
 		const commit = fakeCommit({ committerName: props.committerName })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCommitterNamePatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the committer's name", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -47,7 +51,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCommitterNamePatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -72,7 +76,7 @@ describe.each`
 		const commit = fakeCommit({ committerName: props.committerName })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useCommitterNamePatterns([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -80,7 +84,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useCommitterNamePatterns([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -101,7 +105,7 @@ describe("when verifying a set of multiple commits and some commits have committ
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCommitterNamePatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with invalid committer names", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -113,7 +117,7 @@ describe("when verifying a set of multiple commits and some commits have committ
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCommitterNamePatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -131,7 +135,7 @@ describe("when verifying a set of multiple commits and all commits have committe
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useCommitterNamePatterns(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -139,7 +143,7 @@ describe("when verifying a set of multiple commits and all commits have committe
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useCommitterNamePatterns(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseConciseSubjectLines.tests.ts
+++ b/src/domains/rules/UseConciseSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -16,7 +15,7 @@ const enabled20: RuleOptions<typeof rule> = { maxLength: 20 }
 const enabled50: RuleOptions<typeof rule> = { maxLength: 50 }
 const enabled72: RuleOptions<typeof rule> = { maxLength: 72 }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                                                             | expectedRange20 | expectedRange50 | expectedRange72

--- a/src/domains/rules/UseConciseSubjectLines.tests.ts
+++ b/src/domains/rules/UseConciseSubjectLines.tests.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import type { RuleConfiguration } from "#configurations/Configuration.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useConciseSubjectLines } from "#rules/UseConciseSubjectLines.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useConciseSubjectLines" satisfies RuleKey
-const enabled20: RuleOptions<typeof rule> = { maxLength: 20 }
-const enabled50: RuleOptions<typeof rule> = { maxLength: 50 }
-const enabled72: RuleOptions<typeof rule> = { maxLength: 72 }
+
+const disabled = emptyRuleConfiguration()
+const enabled20 = emptyRuleConfiguration({ [rule]: { maxLength: 20 } })
+const enabled50 = emptyRuleConfiguration({ [rule]: { maxLength: 50 } })
+const enabled72 = emptyRuleConfiguration({ [rule]: { maxLength: 72 } })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -33,7 +36,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -43,7 +46,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -53,7 +56,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled72)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -63,7 +66,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -88,7 +91,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -98,7 +101,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -108,7 +111,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -116,7 +119,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -140,7 +143,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -150,7 +153,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled50)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -160,7 +163,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -168,7 +171,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -196,7 +199,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with a maximum length of 20 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled20)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled20)
 
 			it("raises a concern about the characters that exceed the limit", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -206,7 +209,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 50 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled50)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled50)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -214,7 +217,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a maximum length of 72 characters", () => {
-			const actualConcerns = useConciseSubjectLines([commit], enabled72)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled72)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -222,7 +225,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -250,14 +253,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe.each`
-			options
+			rules
 			${enabled20}
 			${enabled50}
 			${enabled72}
 		`(
-			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useConciseSubjectLines([commit], options)
+			"and the rule is enabled with a maximum length of $rules.useConciseSubjectLines.maxLength characters",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -266,7 +269,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -285,14 +288,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe.each`
-			options
+			rules
 			${enabled20}
 			${enabled50}
 			${enabled72}
 		`(
-			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useConciseSubjectLines([commit], options)
+			"and the rule is enabled with a maximum length of $rules.useConciseSubjectLines.maxLength characters",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -301,7 +304,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -326,14 +329,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe.each`
-			options
+			rules
 			${enabled20}
 			${enabled50}
 			${enabled72}
 		`(
-			"and the rule is enabled with a maximum length of $options.maxLength characters",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useConciseSubjectLines([commit], options)
+			"and the rule is enabled with a maximum length of $rules.useConciseSubjectLines.maxLength characters",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -342,7 +345,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useConciseSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -377,7 +380,7 @@ describe("when verifying a set of multiple commits and some commits have long su
 	]
 
 	describe("and the rule is enabled with a maximum length of 20 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled20)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled20)
 
 		it("raises concerns about the commits whose subject lines exceed 20 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -395,7 +398,7 @@ describe("when verifying a set of multiple commits and some commits have long su
 	})
 
 	describe("and the rule is enabled with a maximum length of 50 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled50)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled50)
 
 		it("raises concerns about the commits whose subject lines exceed 50 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -407,7 +410,7 @@ describe("when verifying a set of multiple commits and some commits have long su
 	})
 
 	describe("and the rule is enabled with a maximum length of 72 characters", () => {
-		const actualConcerns = useConciseSubjectLines(commits, enabled72)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled72)
 
 		it("raises concerns about the commits whose subject lines exceed 72 characters", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -418,7 +421,7 @@ describe("when verifying a set of multiple commits and some commits have long su
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useConciseSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -435,14 +438,14 @@ describe("when verifying a set of multiple commits and all commits have concise 
 	]
 
 	describe.each`
-		options
+		rules
 		${enabled20}
 		${enabled50}
 		${enabled72}
 	`(
-		"and the rule is enabled with a maximum length of $options.maxLength characters",
-		(options: RuleOptions<typeof rule>) => {
-			const actualConcerns = useConciseSubjectLines(commits, options)
+		"and the rule is enabled with a maximum length of $rules.useConciseSubjectLines.maxLength characters",
+		(configProps: { rules: RuleConfiguration }) => {
+			const actualConcerns = mapCommitsToConcerns(commits, configProps.rules)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -451,7 +454,7 @@ describe("when verifying a set of multiple commits and all commits have concise 
 	)
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useConciseSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseEmptyLineBeforeBodyLines.tests.ts
+++ b/src/domains/rules/UseEmptyLineBeforeBodyLines.tests.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { bodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useEmptyLineBeforeBodyLines } from "#rules/UseEmptyLineBeforeBodyLines.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useEmptyLineBeforeBodyLines" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -25,7 +27,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.message })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines([commit], enabled)
+		const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -33,7 +35,7 @@ describe.each`
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines([commit], null)
+		const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -53,7 +55,7 @@ describe.each`
 	const commit = fakeCommit({ message: props.message })
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines([commit], enabled)
+		const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -61,7 +63,7 @@ describe.each`
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines([commit], null)
+		const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -83,7 +85,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.message })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first body line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -96,7 +98,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -119,7 +121,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.message })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first non-blank body line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -132,7 +134,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -153,7 +155,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.message })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -161,7 +163,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useEmptyLineBeforeBodyLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -180,7 +182,7 @@ describe("when verifying a set of multiple commits and some commits do not have 
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with unexpected body lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -191,7 +193,7 @@ describe("when verifying a set of multiple commits and some commits do not have 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -209,7 +211,7 @@ describe("when verifying a set of multiple commits and all commits has exactly o
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -217,7 +219,7 @@ describe("when verifying a set of multiple commits and all commits has exactly o
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useEmptyLineBeforeBodyLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseEmptyLineBeforeBodyLines.tests.ts
+++ b/src/domains/rules/UseEmptyLineBeforeBodyLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { bodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -12,7 +11,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "useEmptyLineBeforeBodyLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	message

--- a/src/domains/rules/UseImperativeSubjectLines.tests.ts
+++ b/src/domains/rules/UseImperativeSubjectLines.tests.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useImperativeSubjectLines } from "#rules/UseImperativeSubjectLines.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useImperativeSubjectLines" satisfies RuleKey
 
-const enabled: RuleOptions<typeof rule> = { whitelist: [] }
-const enabledWhitelist: RuleOptions<typeof rule> = { whitelist: ["chatify", "DECKENIZE"] }
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: { whitelist: [] } })
+const enabledWhitelist = emptyRuleConfiguration({ [rule]: { whitelist: ["chatify", "DECKENIZE"] } })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -44,7 +45,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first word", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -54,7 +55,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a custom whitelist", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabledWhitelist)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledWhitelist)
 
 			it("raises a concern about the first word", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -64,7 +65,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -95,7 +96,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -103,7 +104,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a custom whitelist", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabledWhitelist)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledWhitelist)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -111,7 +112,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -132,7 +133,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled without a custom whitelist", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the first word", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -142,7 +143,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a custom whitelist", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabledWhitelist)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledWhitelist)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -150,7 +151,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -173,7 +174,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -181,7 +182,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -203,7 +204,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -211,7 +212,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with a custom whitelist", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], enabledWhitelist)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledWhitelist)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -219,7 +220,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useImperativeSubjectLines([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -240,7 +241,7 @@ describe("when verifying a set of multiple commits and some commits do not start
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits with non-imperative subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -253,7 +254,7 @@ describe("when verifying a set of multiple commits and some commits do not start
 	})
 
 	describe("and the rule is enabled with a custom whitelist", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, enabledWhitelist)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledWhitelist)
 
 		it("raises concerns about the commits with non-imperative and non-whitelisted subject lines", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -265,7 +266,7 @@ describe("when verifying a set of multiple commits and some commits do not start
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -284,7 +285,7 @@ describe("when verifying a set of multiple commits and all commits start with an
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -292,7 +293,7 @@ describe("when verifying a set of multiple commits and all commits start with an
 	})
 
 	describe("and the rule is enabled with a custom whitelist", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, enabledWhitelist)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledWhitelist)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -300,7 +301,7 @@ describe("when verifying a set of multiple commits and all commits start with an
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useImperativeSubjectLines(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseImperativeSubjectLines.tests.ts
+++ b/src/domains/rules/UseImperativeSubjectLines.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -14,7 +13,7 @@ const rule = "useImperativeSubjectLines" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = { whitelist: [] }
 const enabledWhitelist: RuleOptions<typeof rule> = { whitelist: ["chatify", "DECKENIZE"] }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                       | expectedRange

--- a/src/domains/rules/UseIssueLinks.tests.ts
+++ b/src/domains/rules/UseIssueLinks.tests.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
+import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { issueLinkConfiguration } from "#configurations/IssueLinkTokenConfiguration.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
@@ -18,7 +18,7 @@ const enabledAnywhere: RuleOptions<typeof rule> = { position: "anywhere" }
 const enabledPrefix: RuleOptions<typeof rule> = { position: "prefix" }
 const enabledSuffix: RuleOptions<typeof rule> = { position: "suffix" }
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine                                                  | expectedRangeAnywhere | expectedRangePrefix | expectedRangeSuffix
@@ -468,9 +468,7 @@ describe("when verifying a set of multiple commits and all commits end with an i
 })
 
 const fakeJiraStyleCommit = fakeCommitFactory(
-	fakeConfiguration({
-		tokens: { issueLinks: issueLinkConfiguration(["UNICORN-"]) },
-	}),
+	fakeTokenConfiguration({ issueLinks: issueLinkConfiguration(["UNICORN-"]) }),
 )
 
 describe.each`

--- a/src/domains/rules/UseIssueLinks.tests.ts
+++ b/src/domains/rules/UseIssueLinks.tests.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeTokenConfiguration } from "#configurations/Configuration.fixtures.ts"
+import {
+	emptyRuleConfiguration,
+	fakeTokenConfiguration,
+} from "#configurations/Configuration.fixtures.ts"
+import type { RuleConfiguration } from "#configurations/Configuration.ts"
 import { issueLinkConfiguration } from "#configurations/IssueLinkTokenConfiguration.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
 import { subjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useIssueLinks } from "#rules/UseIssueLinks.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { CharacterRange } from "#types/CharacterRange.ts"
 import { fakeCommitSha } from "#types/CommitSha.fixtures.ts"
 import type { CommitSha } from "#types/CommitSha.ts"
@@ -14,9 +17,10 @@ import type { Vector } from "#types/Vector.ts"
 
 const rule = "useIssueLinks" satisfies RuleKey
 
-const enabledAnywhere: RuleOptions<typeof rule> = { position: "anywhere" }
-const enabledPrefix: RuleOptions<typeof rule> = { position: "prefix" }
-const enabledSuffix: RuleOptions<typeof rule> = { position: "suffix" }
+const disabled = emptyRuleConfiguration()
+const enabledAnywhere = emptyRuleConfiguration({ [rule]: { position: "anywhere" } })
+const enabledPrefix = emptyRuleConfiguration({ [rule]: { position: "prefix" } })
+const enabledSuffix = emptyRuleConfiguration({ [rule]: { position: "suffix" } })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -38,7 +42,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("raises a concern about the beginning of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -48,7 +52,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("raises a concern about the beginning of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -58,7 +62,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("raises a concern about the end of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -68,7 +72,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -90,7 +94,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -98,7 +102,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -106,7 +110,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("raises a concern about the end of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -116,7 +120,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -138,7 +142,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -146,7 +150,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("raises a concern about the start of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -156,7 +160,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -164,7 +168,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -188,7 +192,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -196,7 +200,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("raises a concern about the start of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -206,7 +210,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("raises a concern about the end of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -216,7 +220,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -236,14 +240,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe.each`
-			options
+			rules
 			${enabledAnywhere}
 			${enabledPrefix}
 			${enabledSuffix}
 		`(
-			"and the rule is enabled with position '$options.position'",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useIssueLinks([commit], options)
+			"and the rule is enabled with position $rules.useIssueLinks.position",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -252,7 +256,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -280,14 +284,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine })
 
 		describe.each`
-			options
+			rules
 			${enabledAnywhere}
 			${enabledPrefix}
 			${enabledSuffix}
 		`(
-			"and the rule is enabled with position '$options.position'",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useIssueLinks([commit], options)
+			"and the rule is enabled with position $rules.useIssueLinks.position",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -296,7 +300,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -316,14 +320,14 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, parents: props.parents })
 
 		describe.each`
-			options
+			rules
 			${enabledAnywhere}
 			${enabledPrefix}
 			${enabledSuffix}
 		`(
-			"and the rule is enabled with position '$options.position'",
-			(options: RuleOptions<typeof rule>) => {
-				const actualConcerns = useIssueLinks([commit], options)
+			"and the rule is enabled with position $rules.useIssueLinks.position",
+			(configProps: { rules: RuleConfiguration }) => {
+				const actualConcerns = mapCommitsToConcerns([commit], configProps.rules)
 
 				it("does not raise any concerns", () => {
 					expect(actualConcerns).toEqual<Concerns>([])
@@ -332,7 +336,7 @@ describe.each`
 		)
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -354,7 +358,7 @@ describe("when verifying a set of multiple commits and some commits are missing 
 	]
 
 	describe("and the rule is enabled with position 'anywhere'", () => {
-		const actualConcerns = useIssueLinks(commits, enabledAnywhere)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledAnywhere)
 
 		it("raises concerns about commits without an issue link", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -365,7 +369,7 @@ describe("when verifying a set of multiple commits and some commits are missing 
 	})
 
 	describe("and the rule is enabled with position 'prefix'", () => {
-		const actualConcerns = useIssueLinks(commits, enabledPrefix)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledPrefix)
 
 		it("raises concerns about commits whose issue link is not at the prefix", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -378,7 +382,7 @@ describe("when verifying a set of multiple commits and some commits are missing 
 	})
 
 	describe("and the rule is enabled with position 'suffix'", () => {
-		const actualConcerns = useIssueLinks(commits, enabledSuffix)
+		const actualConcerns = mapCommitsToConcerns(commits, enabledSuffix)
 
 		it("raises concerns about commits whose issue link is not at the suffix", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -393,7 +397,7 @@ describe("when verifying a set of multiple commits and some commits are missing 
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useIssueLinks(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -411,13 +415,13 @@ describe("when verifying a set of multiple commits and all commits start with an
 	]
 
 	describe.each`
-		options
+		rules
 		${enabledAnywhere}
 		${enabledPrefix}
 	`(
-		"and the rule is enabled with position '$options.position'",
-		(options: RuleOptions<typeof rule>) => {
-			const actualConcerns = useIssueLinks(commits, options)
+		"and the rule is enabled with position $rules.useIssueLinks.position",
+		(configProps: { rules: RuleConfiguration }) => {
+			const actualConcerns = mapCommitsToConcerns(commits, configProps.rules)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -426,7 +430,7 @@ describe("when verifying a set of multiple commits and all commits start with an
 	)
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useIssueLinks(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -444,13 +448,13 @@ describe("when verifying a set of multiple commits and all commits end with an i
 	]
 
 	describe.each`
-		options
+		rules
 		${enabledAnywhere}
 		${enabledSuffix}
 	`(
-		"and the rule is enabled with position '$options.position'",
-		(options: RuleOptions<typeof rule>) => {
-			const actualConcerns = useIssueLinks(commits, options)
+		"and the rule is enabled with position $rules.useIssueLinks.position",
+		(configProps: { rules: RuleConfiguration }) => {
+			const actualConcerns = mapCommitsToConcerns(commits, configProps.rules)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -459,7 +463,7 @@ describe("when verifying a set of multiple commits and all commits end with an i
 	)
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useIssueLinks(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -489,7 +493,7 @@ describe.each`
 		const commit = fakeJiraStyleCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("raises a concern about the beginning of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -499,7 +503,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("raises a concern about the beginning of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -509,7 +513,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("raises a concern about the end of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -519,7 +523,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -541,7 +545,7 @@ describe.each`
 		const commit = fakeJiraStyleCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -549,7 +553,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -557,7 +561,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("raises a concern about the end of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -567,7 +571,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -589,7 +593,7 @@ describe.each`
 		const commit = fakeJiraStyleCommit({ message: props.subjectLine })
 
 		describe("and the rule is enabled with position 'anywhere'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledAnywhere)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledAnywhere)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -597,7 +601,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'prefix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledPrefix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledPrefix)
 
 			it("raises a concern about the start of the subject line", () => {
 				expect(actualConcerns).toEqual<Concerns>([
@@ -607,7 +611,7 @@ describe.each`
 		})
 
 		describe("and the rule is enabled with position 'suffix'", () => {
-			const actualConcerns = useIssueLinks([commit], enabledSuffix)
+			const actualConcerns = mapCommitsToConcerns([commit], enabledSuffix)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -615,7 +619,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useIssueLinks([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/UseSignedCommits.tests.ts
+++ b/src/domains/rules/UseSignedCommits.tests.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
-import { fakeConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { Concerns } from "#rules/concerns/Concern.ts"
 import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
@@ -11,7 +10,7 @@ import type { Vector } from "#types/Vector.ts"
 const rule = "useSignedCommits" satisfies RuleKey
 const enabled: RuleOptions<typeof rule> = {}
 
-const fakeCommit = fakeCommitFactory(fakeConfiguration())
+const fakeCommit = fakeCommitFactory()
 
 describe.each`
 	subjectLine

--- a/src/domains/rules/UseSignedCommits.tests.ts
+++ b/src/domains/rules/UseSignedCommits.tests.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest"
 import { fakeCommitFactory } from "#commits/Commit.fixtures.ts"
 import type { Commit } from "#commits/Commit.ts"
+import { emptyRuleConfiguration } from "#configurations/Configuration.fixtures.ts"
 import { commitConcern } from "#rules/concerns/CommitConcern.ts"
-import type { Concerns } from "#rules/concerns/Concern.ts"
-import type { RuleKey, RuleOptions } from "#rules/Rule.ts"
-import { useSignedCommits } from "#rules/UseSignedCommits.ts"
+import { type Concerns, mapCommitsToConcerns } from "#rules/concerns/Concern.ts"
+import type { RuleKey } from "#rules/Rule.ts"
 import type { Vector } from "#types/Vector.ts"
 
 const rule = "useSignedCommits" satisfies RuleKey
-const enabled: RuleOptions<typeof rule> = {}
+
+const disabled = emptyRuleConfiguration()
+const enabled = emptyRuleConfiguration({ [rule]: {} })
 
 const fakeCommit = fakeCommitFactory()
 
@@ -22,7 +24,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, signature: "" })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useSignedCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("raises a concern about the entire commit", () => {
 				expect(actualConcerns).toEqual<Concerns>([commitConcern(rule, commit.sha)])
@@ -30,7 +32,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useSignedCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -49,7 +51,7 @@ describe.each`
 		const commit = fakeCommit({ message: props.subjectLine, signature: props.signature })
 
 		describe("and the rule is enabled", () => {
-			const actualConcerns = useSignedCommits([commit], enabled)
+			const actualConcerns = mapCommitsToConcerns([commit], enabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -57,7 +59,7 @@ describe.each`
 		})
 
 		describe("and the rule is disabled", () => {
-			const actualConcerns = useSignedCommits([commit], null)
+			const actualConcerns = mapCommitsToConcerns([commit], disabled)
 
 			it("does not raise any concerns", () => {
 				expect(actualConcerns).toEqual<Concerns>([])
@@ -87,7 +89,7 @@ describe("when verifying a set of multiple commits and some commits lack a signa
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useSignedCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("raises concerns about the commits without a signature", () => {
 			expect(actualConcerns).toEqual<Concerns>([
@@ -100,7 +102,7 @@ describe("when verifying a set of multiple commits and some commits lack a signa
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useSignedCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -129,7 +131,7 @@ describe("when verifying a set of multiple commits and all commits have signatur
 	]
 
 	describe("and the rule is enabled", () => {
-		const actualConcerns = useSignedCommits(commits, enabled)
+		const actualConcerns = mapCommitsToConcerns(commits, enabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])
@@ -137,7 +139,7 @@ describe("when verifying a set of multiple commits and all commits have signatur
 	})
 
 	describe("and the rule is disabled", () => {
-		const actualConcerns = useSignedCommits(commits, null)
+		const actualConcerns = mapCommitsToConcerns(commits, disabled)
 
 		it("does not raise any concerns", () => {
 			expect(actualConcerns).toEqual<Concerns>([])

--- a/src/domains/rules/concerns/Concern.ts
+++ b/src/domains/rules/concerns/Concern.ts
@@ -1,5 +1,5 @@
 import type { Commit, Commits } from "#commits/Commit.ts"
-import type { Configuration } from "#configurations/Configuration.ts"
+import type { RuleConfiguration } from "#configurations/Configuration.ts"
 import type { BodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
 import type { CommitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { SubjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
@@ -36,8 +36,7 @@ export function concernedCommit(concern: Concern, commits: Commits): Commit {
 	)
 }
 
-export function mapCommitsToConcerns(commits: Commits, configuration: Configuration): Concerns {
-	const rules = configuration.rules
+export function mapCommitsToConcerns(commits: Commits, rules: RuleConfiguration): Concerns {
 	return [
 		...noExcessiveCommitsPerBranch(commits, rules.noExcessiveCommitsPerBranch),
 		...noMergeCommits(commits, rules.noMergeCommits),

--- a/src/domains/rules/concerns/Concern.ts
+++ b/src/domains/rules/concerns/Concern.ts
@@ -4,6 +4,7 @@ import type { BodyLineConcern } from "#rules/concerns/BodyLineConcern.ts"
 import type { CommitConcern } from "#rules/concerns/CommitConcern.ts"
 import type { SubjectLineConcern } from "#rules/concerns/SubjectLineConcern.ts"
 import type { UserIdentityConcern } from "#rules/concerns/UserIdentityConcern.ts"
+import { noBlankSubjectLines } from "#rules/NoBlankSubjectLines.ts"
 import { noExcessiveCommitsPerBranch } from "#rules/NoExcessiveCommitsPerBranch.ts"
 import { noMergeCommits } from "#rules/NoMergeCommits.ts"
 import { noRepeatedSubjectLines } from "#rules/NoRepeatedSubjectLines.ts"
@@ -38,6 +39,7 @@ export function concernedCommit(concern: Concern, commits: Commits): Commit {
 
 export function mapCommitsToConcerns(commits: Commits, rules: RuleConfiguration): Concerns {
 	return [
+		...noBlankSubjectLines(commits, rules.noBlankSubjectLines),
 		...noExcessiveCommitsPerBranch(commits, rules.noExcessiveCommitsPerBranch),
 		...noMergeCommits(commits, rules.noMergeCommits),
 		...noRepeatedSubjectLines(commits, rules.noRepeatedSubjectLines),

--- a/src/domains/rules/reports/CommitwiseReport.tests.ts
+++ b/src/domains/rules/reports/CommitwiseReport.tests.ts
@@ -26,7 +26,7 @@ describe("when there are no concerns", () => {
 
 describe("when 'noBlankSubjectLines' has a concern about characters 0-1 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "52f07a2d665e6d3b3b50b8fca2af298c100ac804c",
@@ -49,7 +49,7 @@ describe("when 'noBlankSubjectLines' has a concern about characters 0-1 of the s
 
 describe("when 'noBlankSubjectLines' has a concern about characters 15-16 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "2ba57d6e3490324db1bacf22ae288481357ef5c",
@@ -74,7 +74,7 @@ describe("when 'noExcessiveCommitsPerBranch' has a concern about an excessive co
 	const configuration = fakeConfiguration({
 		rules: { noExcessiveCommitsPerBranch: { maxCommits: 1 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "9a7e6aa14b8c6e5dd49d7a6a18443bf1f67c520",
@@ -99,7 +99,7 @@ describe("when 'noExcessiveCommitsPerBranch' has a concern about an excessive co
 	const configuration = fakeConfiguration({
 		rules: { noExcessiveCommitsPerBranch: { maxCommits: 3 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "75bedf83e2b573dc812eba9f14f2b7c6741e670",
@@ -124,7 +124,7 @@ describe("when 'noExcessiveCommitsPerBranch' has a concern about an excessive co
 	const configuration = fakeConfiguration({
 		rules: { noExcessiveCommitsPerBranch: { maxCommits: 10 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "f753a247a54bb4c20e9968dca75ef915f2b1ca",
@@ -147,7 +147,7 @@ f753a24 last minute fix
 
 describe("when 'noMergeCommits' has a concern about the commit", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "507c835ff93e38ed1540ff58fb72f7837f9af13",
@@ -171,7 +171,7 @@ describe("when 'noMergeCommits' has a concern about the commit", () => {
 
 describe("when 'noMergeCommits' has a concern about the commit with a long subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "71516e17c94c69de4eeafff60fac072764d2",
@@ -195,7 +195,7 @@ describe("when 'noMergeCommits' has a concern about the commit with a long subje
 
 describe("when 'noRepeatedSubjectLines' has a concern about the commit", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "8c1fbd48d21686c574a01fd2db4be1c991d897",
@@ -218,7 +218,7 @@ describe("when 'noRepeatedSubjectLines' has a concern about the commit", () => {
 
 describe("when 'noRepeatedSubjectLines' has a concern about the commit with a long subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "f3359c9a89b46736a36fa2117515af2f5c93",
@@ -248,7 +248,7 @@ describe("when 'noRestrictedTrailers' has a concern about a body line with a 'Co
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "a04ada44cc2d13336a7b28cfb7bd59649aa1bb",
@@ -287,7 +287,7 @@ describe("when 'noRestrictedTrailers' has a concern about a body line with a 'Re
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "344eaa9c854379fbd1af020aaf093fbad974c3",
@@ -321,7 +321,7 @@ describe("when 'noRestrictedTrailers' has a concern about a body line with a 'Re
 
 describe("when 'noRevertRevertCommits' has a concern about characters 0-16 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "d4e7a978cea34b727ea52f90c928fd535e4aee",
@@ -344,7 +344,7 @@ d4e7a97 Revert "Revert "Make the program act like a clown""
 
 describe("when 'noRevertRevertCommits' has a concern about characters 1-26 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "34aa41b818c40682cabeecd5623dfe51df7a4a5",
@@ -367,7 +367,7 @@ describe("when 'noRevertRevertCommits' has a concern about characters 1-26 of th
 
 describe("when 'noSingleWordSubjectLines' has a concern about characters 0-3 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "964bce7ef85bb4347a0882c5d43c8cece4938f",
@@ -390,7 +390,7 @@ describe("when 'noSingleWordSubjectLines' has a concern about characters 0-3 of 
 
 describe("when 'noSingleWordSubjectLines' has a concern about characters 11-17 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "a4b6d0e1aee11f7bc39dfd68858257e236256fbf",
@@ -413,7 +413,7 @@ a4b6d0e fixup! #17 bugfix
 
 describe("when 'noSquashMarkers' has a concern about characters 0-6 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "ffebad193fe7d02aa9b19b70ee132a26f14f8caf",
@@ -436,7 +436,7 @@ ffebad1 amend!Apply strawberry jam to make the code sweeter
 
 describe("when 'noSquashMarkers' has a concern about characters 1-14 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "56c750b0811fbcad2b237b2b99fc7d3fc91b926",
@@ -459,7 +459,7 @@ describe("when 'noSquashMarkers' has a concern about characters 1-14 of the subj
 
 describe("when 'useCapitalisedSubjectLines' has a concern about characters 0-1 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "497de39943643a56f7a69d3d19723e3035318644",
@@ -482,7 +482,7 @@ describe("when 'useCapitalisedSubjectLines' has a concern about characters 0-1 o
 
 describe("when 'useCapitalisedSubjectLines' has a concern about characters 7-8 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "92d6b11650c6b63d64fd77522241b7f50ff5b",
@@ -511,7 +511,7 @@ describe("when 'useAuthorEmailPatterns' has a concern about a missing author ema
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "87c2ab2dff91967340adee6a79d40f4fd6b781b",
@@ -550,7 +550,7 @@ describe("when 'useAuthorEmailPatterns' has a concern about the author's email a
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "4014427db76e7f114209216c738649e9e1505f",
@@ -587,7 +587,7 @@ describe("when 'useAuthorNamePatterns' has a concern about a missing author name
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "f16fc9f48c40829a87cbc36f42aa6578834ed0c6",
@@ -623,7 +623,7 @@ describe("when 'useAuthorNamePatterns' has a concern about the author's name", (
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "e4236bf51670f99f245f3a5552fa2b7e6bd8c1",
@@ -660,7 +660,7 @@ describe("when 'useCommitterEmailPatterns' has a concern about a missing committ
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "28a5bed21c189fc505af3696c7ff7a3a79524e",
@@ -699,7 +699,7 @@ describe("when 'useCommitterEmailPatterns' has a concern about the committer's e
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "55ef98aa89887ba6937a616b6044c7da57f7a",
@@ -736,7 +736,7 @@ describe("when 'useCommitterNamePatterns' has a concern about a missing committe
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "307ce5e6cfe9fbb67f62ca3d40447e9143fb8d38",
@@ -777,7 +777,7 @@ describe("when 'useCommitterNamePatterns' has a concern about the committer's na
 			},
 		},
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "61a6e5334d93126cec5c594bd75a3c7fee7ec",
@@ -810,7 +810,7 @@ describe("when 'useCommitterNamePatterns' has a concern about the committer's na
 
 describe("when 'useImperativeSubjectLines' has a concern about characters 0-5 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "9e45e097a594deaf39b360fb285be38b5b68a2",
@@ -833,7 +833,7 @@ describe("when 'useImperativeSubjectLines' has a concern about characters 0-5 of
 
 describe("when 'useImperativeSubjectLines' has a concern about characters 14-18 of the subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "339b6fcb8aedbe7b19443e39be24f615287a7",
@@ -858,7 +858,7 @@ describe("when 'useConciseSubjectLines' has a concern about characters 20-25 of 
 	const configuration = fakeConfiguration({
 		rules: { useConciseSubjectLines: { maxLength: 20 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "68e921648c4a19e93d72f42a5d39c3eba704e41",
@@ -883,7 +883,7 @@ describe("when 'useConciseSubjectLines' has a concern about characters 20-67 of 
 	const configuration = fakeConfiguration({
 		rules: { useConciseSubjectLines: { maxLength: 20 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "9bed522bd48f0aee7574635bb23f5decdc4999",
@@ -908,7 +908,7 @@ describe("when 'useConciseSubjectLines' has a concern about characters 50-52 of 
 	const configuration = fakeConfiguration({
 		rules: { useConciseSubjectLines: { maxLength: 50 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "e8c95d69587a51685070837aaf3a8746e3cbba8",
@@ -933,7 +933,7 @@ describe("when 'useConciseSubjectLines' has a concern about characters 72-76 of 
 	const configuration = fakeConfiguration({
 		rules: { useConciseSubjectLines: { maxLength: 72 } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "be86674322213fb408d176589fadbcd44a2df",
@@ -956,7 +956,7 @@ be86674 make a genuine attempt to fix the bugs that the users were complaining a
 
 describe("when 'useEmptyLineBeforeBodyLines' has a concern about the first body line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "f163851c187a568acc631fff402fcca43f41968d",
@@ -985,7 +985,7 @@ f163851 Install a quieter keyboard
 
 describe("when 'useEmptyLineBeforeBodyLines' has a concern about an extra empty body line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "30fd57b19c55b3746a157f5981838e26865637f2",
@@ -1018,7 +1018,7 @@ describe("when 'useIssueLinks' with position 'anywhere' has a concern about char
 	const configuration = fakeConfiguration({
 		rules: { useIssueLinks: { position: "anywhere" } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "c861aeae9dcdea99776d1e56c4de100ba29effb",
@@ -1045,7 +1045,7 @@ describe("when 'useIssueLinks' with position 'prefix' has a concern about charac
 	const configuration = fakeConfiguration({
 		rules: { useIssueLinks: { position: "prefix" } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "fb100238cf55fdcc7c48044df4b5922c0886f5c2d",
@@ -1072,7 +1072,7 @@ describe("when 'useIssueLinks' with position 'suffix' has a concern about charac
 	const configuration = fakeConfiguration({
 		rules: { useIssueLinks: { position: "suffix" } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "d9a30bb22c78cf24fc6a79a3131a33829792bd4",
@@ -1099,7 +1099,7 @@ describe("when 'useIssueLinks' with position 'suffix' has a concern about charac
 	const configuration = fakeConfiguration({
 		rules: { useIssueLinks: { position: "suffix" } },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "5761bad8f4bbdd9f22eac552ca15a42dd547692",
@@ -1127,7 +1127,7 @@ describe("when 'useIssueLinks' with position 'anywhere' and a wildcard has a con
 		rules: { useIssueLinks: { position: "anywhere" } },
 		tokens: { issueLinks: issueLinkConfiguration(["#"], ["(no-issue)"]) },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "ca745a72a024df3e612faeb3dc10090eb367c18a9",
@@ -1155,7 +1155,7 @@ describe("when 'useIssueLinks' with position 'anywhere' and Jira-style issue lin
 		rules: { useIssueLinks: { position: "anywhere" } },
 		tokens: { issueLinks: issueLinkConfiguration(["ABC-"]) },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "d0709d2e4d2c55bf37ec7e7632f655e8e9b3eb",
@@ -1183,7 +1183,7 @@ describe("when 'useIssueLinks' with position 'prefix' and custom-style issue lin
 		rules: { useIssueLinks: { position: "prefix" } },
 		tokens: { issueLinks: issueLinkConfiguration(["test#", "experiment#"], ["[incident]"]) },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "f6fc2399d62caefc3e4bfd8bf2a8da28fffafe",
@@ -1211,7 +1211,7 @@ describe("when 'useIssueLinks' with position 'suffix' and Jira-style issue links
 		rules: { useIssueLinks: { position: "suffix" } },
 		tokens: { issueLinks: issueLinkConfiguration(["AWESOME-", "UNICORN-", "PROJECT-"]) },
 	})
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "cccee2c633f0e65d939df7d9953f59ee9322c323",
@@ -1236,7 +1236,7 @@ cccee2c Fixed a bad typo in comment (yes, really)
 
 describe("when 'useSignedCommits' has a concern about the commit", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "9b9e2ab8f3248152474f41f728f1221d5bf55a16",
@@ -1260,7 +1260,7 @@ describe("when 'useSignedCommits' has a concern about the commit", () => {
 
 describe("when 'useSignedCommits' has a concern about the commit with a long subject line", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commit = fakeCommit({
 		sha: "42cefd126a47bfd368d774047a711519eadc2d5",
@@ -1284,7 +1284,7 @@ describe("when 'useSignedCommits' has a concern about the commit with a long sub
 
 describe.todo("when there are multiple concerns of different types", () => {
 	const configuration = fakeConfiguration()
-	const fakeCommit = fakeCommitFactory(configuration)
+	const fakeCommit = fakeCommitFactory(configuration.tokens)
 
 	const commits: Vector<Commit, 3> = [fakeCommit(), fakeCommit(), fakeCommit()]
 	const concerns: Concerns = []


### PR DESCRIPTION
This brings `mapCommitsToConcerns` under test coverage, ensuring that every rule is included in the mapper. It also unifies some imports across test files.